### PR TITLE
Add localization framework with sample bindings

### DIFF
--- a/StroopApp/App.xaml
+++ b/StroopApp/App.xaml
@@ -5,6 +5,7 @@
              xmlns:ui="http://schemas.modernwpf.com/2019">
     <Application.Resources>
         <ResourceDictionary>
+            <local:LocalizedStrings x:Key="Loc" />
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemeResources RequestedTheme="Light" AccentColor="CornflowerBlue"/>
                 <ui:XamlControlsResources />

--- a/StroopApp/LocalizedStrings.cs
+++ b/StroopApp/LocalizedStrings.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace StroopApp
+{
+    public class LocalizedStrings : INotifyPropertyChanged
+    {
+        private CultureInfo _culture = new CultureInfo("en-US");
+
+        public string this[string key] => Resources.Strings.ResourceManager.GetString(key, _culture) ?? key;
+
+        public CultureInfo CurrentCulture => _culture;
+
+        public void SetCulture(string cultureName)
+        {
+            _culture = new CultureInfo(cultureName);
+            CultureInfo.DefaultThreadCurrentUICulture = _culture;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}

--- a/StroopApp/Resources/Strings.fr.resx
+++ b/StroopApp/Resources/Strings.fr.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <data name="Configuration_Title" xml:space="preserve">
+    <value>Configuration de l\'expérience</value>
+  </data>
+  <data name="Configuration_Header" xml:space="preserve">
+    <value>Configuration des paramètres de l\'expérience</value>
+  </data>
+  <data name="Button_Launch" xml:space="preserve">
+    <value>Lancer l\'expérience</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+</root>

--- a/StroopApp/Resources/Strings.resx
+++ b/StroopApp/Resources/Strings.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <data name="Configuration_Title" xml:space="preserve">
+    <value>Experiment Configuration</value>
+  </data>
+  <data name="Configuration_Header" xml:space="preserve">
+    <value>Experiment parameters configuration</value>
+  </data>
+  <data name="Button_Launch" xml:space="preserve">
+    <value>Launch experiment</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Language</value>
+  </data>
+</root>

--- a/StroopApp/StroopApp.csproj
+++ b/StroopApp/StroopApp.csproj
@@ -8,7 +8,14 @@
 		<UseWPF>true</UseWPF>
 	</PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\Strings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\Strings.fr.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </EmbeddedResource>
 		<PackageReference Include="ClosedXML" Version="0.104.2" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/StroopApp/Views/Configuration/ConfigurationPage.xaml
+++ b/StroopApp/Views/Configuration/ConfigurationPage.xaml
@@ -5,7 +5,7 @@
       xmlns:viewsProfile="clr-namespace:StroopApp.Views.Profile"
       xmlns:viewsKeyMapping="clr-namespace:StroopApp.Views.KeyMapping"
       xmlns:viewsParticipant="clr-namespace:StroopApp.Views.Participant"
-      Title="Configuration de l'expérience">
+      Title="{Binding Source={StaticResource Loc}, Path=[Configuration_Title]}">
     <Grid x:Name="MainGrid"
           Margin="12">
         <Grid.RowDefinitions>
@@ -18,11 +18,18 @@
             <RowDefinition Height="12" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0"
-                   Text="Configuration des paramètres de l'expérience"
-                   Style="{DynamicResource HeaderTextBlockStyle}"
-                   HorizontalAlignment="Left"
-                   Margin="0,0,0,12" />
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Configuration_Header]}"
+                       Style="{DynamicResource HeaderTextBlockStyle}"
+                       VerticalAlignment="Center" />
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Language]}"
+                       Margin="12,0,4,0" VerticalAlignment="Center" />
+            <ComboBox x:Name="LanguageComboBox" Width="120"
+                      SelectionChanged="LanguageComboBox_SelectionChanged">
+                <ComboBoxItem Content="English" Tag="en-US" IsSelected="True" />
+                <ComboBoxItem Content="Français" Tag="fr-FR" />
+            </ComboBox>
+        </StackPanel>
         <Grid x:Name="KeyMappingContainer"
               Grid.Row="3">
             <Grid.ColumnDefinitions>
@@ -33,7 +40,7 @@
         </Grid>
         <StackPanel Grid.Row="7"
                     HorizontalAlignment="Center">
-            <Button Content="Lancer l'expérience"
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Launch]}"
                     Style="{DynamicResource AccentButtonStyle}"
                     Command="{Binding LaunchExperimentCommand}" />
         </StackPanel>

--- a/StroopApp/Views/Configuration/ConfigurationPage.xaml.cs
+++ b/StroopApp/Views/Configuration/ConfigurationPage.xaml.cs
@@ -15,11 +15,12 @@ using StroopApp.Views.Configuration;
 using StroopApp.Views.KeyMapping;
 using StroopApp.Views.Participant;
 using StroopApp.Views.Profile;
+using System.Windows;
 
 namespace StroopApp.Views
 {
-	public partial class ConfigurationPage : Page
-	{
+        public partial class ConfigurationPage : Page
+        {
 		public ConfigurationPage(ExperimentSettings settings, INavigationService experimentNavigationService, IWindowManager windowManager)
 		{
 			InitializeComponent();
@@ -55,9 +56,20 @@ namespace StroopApp.Views
 			Grid.SetColumn(keyMappingView, 0);
 			KeyMappingContainer.Children.Add(exportFolderView);
 			Grid.SetColumn(exportFolderView, 2);
-			MainGrid.Children.Add(participantManagementView);
-			Grid.SetRow(participantManagementView, 5);
-		}
-	}
+                        MainGrid.Children.Add(participantManagementView);
+                        Grid.SetRow(participantManagementView, 5);
+                }
+
+                private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+                {
+                        if (LanguageComboBox.SelectedItem is ComboBoxItem item && item.Tag is string culture)
+                        {
+                                if (Application.Current.Resources["Loc"] is LocalizedStrings loc)
+                                {
+                                        loc.SetCulture(culture);
+                                }
+                        }
+                }
+        }
 }
 


### PR DESCRIPTION
## Summary
- implement `LocalizedStrings` provider for runtime culture changes
- add English/French resource files
- update `App.xaml` to expose provider
- demo localization on `ConfigurationPage`
- expose runtime language switch

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685058681054832f98fe0825bee0ff52