### PR TITLE
Introduce localized strings

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -14,6 +14,7 @@ namespace StroopApp
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
+            System.Threading.Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en");
             var settings = new ExperimentSettings();
             WindowManager = new WindowManager();
             var expWin = new ExperimentWindow(settings, WindowManager);

--- a/Core/ViewModelBase.cs
+++ b/Core/ViewModelBase.cs
@@ -16,9 +16,10 @@ namespace StroopApp.Core
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         protected async void ShowErrorDialog(string message)
         {
+            var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
             var dialog = new ContentDialog
             {
-                Title = "Erreur",
+                Title = loc?["Error_Title"],
                 Content = message,
                 CloseButtonText = "OK"
             };

--- a/Services/Exportation/ExportationService.cs
+++ b/Services/Exportation/ExportationService.cs
@@ -61,7 +61,10 @@ namespace StroopApp.Services.Exportation
         {
             var root = ExportRootDirectory;
             if (string.IsNullOrWhiteSpace(root))
-                throw new InvalidOperationException("Aucun dossier d'export configuré.");
+            {
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                throw new InvalidOperationException(loc?["Error_NoExportFolder"] ?? "");
+            }
 
             Directory.CreateDirectory(root);
             var resultsDir = Path.Combine(root, "Results");
@@ -113,10 +116,11 @@ namespace StroopApp.Services.Exportation
 
             wb.SaveAs(filePath);
 
+            var locDlg = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
             var dlg = new ContentDialog
             {
-                Title = "Export terminé",
-                Content = $"Fichier enregistré :\n{filePath}",
+                Title = locDlg?["Export_Completed_Title"],
+                Content = string.Format(locDlg?["Export_Completed_Message"] ?? "{0}", filePath),
                 CloseButtonText = "OK"
             };
             await dlg.ShowAsync();

--- a/StroopApp/Resources/Strings.fr.resx
+++ b/StroopApp/Resources/Strings.fr.resx
@@ -120,4 +120,98 @@
   <data name="App_Title" xml:space="preserve">
     <value>Application de tâche cognitive</value>
   </data>
+  <data name="ExperimentWindow_Title" xml:space="preserve">
+    <value>Expérience Stroop</value>
+  </data>
+  <data name="ParticipantWindow_Title" xml:space="preserve">
+    <value>Fenêtre Participant</value>
+  </data>
+  <data name="ConfigPage_Title" xml:space="preserve">
+    <value>Configuration de l'expérience</value>
+  </data>
+  <data name="Button_LaunchExperiment" xml:space="preserve">
+    <value>Lancer l'expérience</value>
+  </data>
+  <data name="Error_SelectProfile" xml:space="preserve">
+    <value>Veuillez sélectionner un profil d'expérience.</value>
+  </data>
+  <data name="Error_SelectParticipant" xml:space="preserve">
+    <value>Veuillez sélectionner un participant.</value>
+  </data>
+  <data name="Error_SelectProfileToModify" xml:space="preserve">
+    <value>Veuillez sélectionner un profil à modifier&nbsp;!</value>
+  </data>
+  <data name="Error_SelectProfileToDelete" xml:space="preserve">
+    <value>Veuillez sélectionner un profil à supprimer&nbsp;!</value>
+  </data>
+  <data name="Error_ProfileNameEmpty" xml:space="preserve">
+    <value>Le nom du profil ne peut pas être vide ou contenir uniquement des espaces.</value>
+  </data>
+  <data name="Error_ProfileNameExists" xml:space="preserve">
+    <value>Un profil avec ce nom existe déjà. Veuillez choisir un autre nom.</value>
+  </data>
+  <data name="Error_WordDurationInvalid" xml:space="preserve">
+    <value>La durée du mot doit être positive et la durée totale doit être divisible par la durée du mot.</value>
+  </data>
+  <data name="Error_GroupSizeInvalid" xml:space="preserve">
+    <value>La taille du groupe doit être positive et diviser le nombre de mots.</value>
+  </data>
+  <data name="Error_AmorceTimeInvalid" xml:space="preserve">
+    <value>Le temps d'amorce doit être supérieur à 0&nbsp;!</value>
+  </data>
+  <data name="Error_MaxReactionInvalid" xml:space="preserve">
+    <value>Le temps de réaction maximum doit être positif.</value>
+  </data>
+  <data name="Error_SelectParticipantToModify" xml:space="preserve">
+    <value>Veuillez sélectionner un participant à modifier&nbsp;!</value>
+  </data>
+  <data name="Error_SelectParticipantToDelete" xml:space="preserve">
+    <value>Veuillez sélectionner un participant à supprimer&nbsp;!</value>
+  </data>
+  <data name="Error_ParticipantFieldsInvalid" xml:space="preserve">
+    <value>Veuillez remplir correctement tous les champs obligatoires.</value>
+  </data>
+  <data name="Error_DuplicateParticipantId" xml:space="preserve">
+    <value>Cet identifiant est déjà utilisé pour un autre participant.</value>
+  </data>
+  <data name="Error_NoExportFolder" xml:space="preserve">
+    <value>Aucun dossier d'export configuré.</value>
+  </data>
+  <data name="Export_Completed_Title" xml:space="preserve">
+    <value>Export terminé</value>
+  </data>
+  <data name="Export_Completed_Message" xml:space="preserve">
+    <value>Fichier enregistré&nbsp;:
+{0}</value>
+  </data>
+  <data name="Error_Title" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="EndExperiment_CurrentParticipant" xml:space="preserve">
+    <value>Participant n°&nbsp;{0}</value>
+  </data>
+  <data name="EndExperiment_CurrentProfile" xml:space="preserve">
+    <value>Tâche&nbsp;: {0}</value>
+  </data>
+  <data name="LiveAverage_Label" xml:space="preserve">
+    <value>Moyenne pour les mots {0}&nbsp;–&nbsp;{1}&nbsp;:</value>
+  </data>
+  <data name="LiveAverage_NoData" xml:space="preserve">
+    <value>Aucune donnée valide</value>
+  </data>
+  <data name="Column_NoResponse" xml:space="preserve">
+    <value>Aucune réponse</value>
+  </data>
+  <data name="DeleteConfirmation_Title" xml:space="preserve">
+    <value>Confirmation de suppression</value>
+  </data>
+  <data name="DeleteConfirmation_Message" xml:space="preserve">
+    <value>Voulez-vous vraiment supprimer ce participant ? Ses données seront archivées.</value>
+  </data>
+  <data name="DeleteConfirmation_Primary" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="DeleteConfirmation_Close" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
 </root>

--- a/StroopApp/Resources/Strings.resx
+++ b/StroopApp/Resources/Strings.resx
@@ -120,4 +120,98 @@
   <data name="App_Title" xml:space="preserve">
     <value>Cognitive Tasks App</value>
   </data>
+  <data name="ExperimentWindow_Title" xml:space="preserve">
+    <value>Stroop Experiment</value>
+  </data>
+  <data name="ParticipantWindow_Title" xml:space="preserve">
+    <value>Participant Window</value>
+  </data>
+  <data name="ConfigPage_Title" xml:space="preserve">
+    <value>Experiment Configuration</value>
+  </data>
+  <data name="Button_LaunchExperiment" xml:space="preserve">
+    <value>Start Experiment</value>
+  </data>
+  <data name="Error_SelectProfile" xml:space="preserve">
+    <value>Please select an experiment profile.</value>
+  </data>
+  <data name="Error_SelectParticipant" xml:space="preserve">
+    <value>Please select a participant.</value>
+  </data>
+  <data name="Error_SelectProfileToModify" xml:space="preserve">
+    <value>Please select a profile to modify!</value>
+  </data>
+  <data name="Error_SelectProfileToDelete" xml:space="preserve">
+    <value>Please select a profile to delete!</value>
+  </data>
+  <data name="Error_ProfileNameEmpty" xml:space="preserve">
+    <value>Profile name cannot be empty or whitespace.</value>
+  </data>
+  <data name="Error_ProfileNameExists" xml:space="preserve">
+    <value>A profile with this name already exists. Choose another name.</value>
+  </data>
+  <data name="Error_WordDurationInvalid" xml:space="preserve">
+    <value>Word duration must be positive and divide task duration.</value>
+  </data>
+  <data name="Error_GroupSizeInvalid" xml:space="preserve">
+    <value>Group size must be positive and divide the number of words.</value>
+  </data>
+  <data name="Error_AmorceTimeInvalid" xml:space="preserve">
+    <value>Prime time must be greater than 0!</value>
+  </data>
+  <data name="Error_MaxReactionInvalid" xml:space="preserve">
+    <value>Maximum reaction time must be positive.</value>
+  </data>
+  <data name="Error_SelectParticipantToModify" xml:space="preserve">
+    <value>Please select a participant to modify!</value>
+  </data>
+  <data name="Error_SelectParticipantToDelete" xml:space="preserve">
+    <value>Please select a participant to delete!</value>
+  </data>
+  <data name="Error_ParticipantFieldsInvalid" xml:space="preserve">
+    <value>Please fill in all required participant fields correctly.</value>
+  </data>
+  <data name="Error_DuplicateParticipantId" xml:space="preserve">
+    <value>This identifier is already used for another participant.</value>
+  </data>
+  <data name="Error_NoExportFolder" xml:space="preserve">
+    <value>No export folder configured.</value>
+  </data>
+  <data name="Export_Completed_Title" xml:space="preserve">
+    <value>Export completed</value>
+  </data>
+  <data name="Export_Completed_Message" xml:space="preserve">
+    <value>File saved:
+{0}</value>
+  </data>
+  <data name="Error_Title" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="EndExperiment_CurrentParticipant" xml:space="preserve">
+    <value>Participant no. {0}</value>
+  </data>
+  <data name="EndExperiment_CurrentProfile" xml:space="preserve">
+    <value>Task: {0}</value>
+  </data>
+  <data name="LiveAverage_Label" xml:space="preserve">
+    <value>Average for words {0}–{1}:</value>
+  </data>
+  <data name="LiveAverage_NoData" xml:space="preserve">
+    <value>No valid data</value>
+  </data>
+  <data name="Column_NoResponse" xml:space="preserve">
+    <value>No response</value>
+  </data>
+  <data name="DeleteConfirmation_Title" xml:space="preserve">
+    <value>Delete confirmation</value>
+  </data>
+  <data name="DeleteConfirmation_Message" xml:space="preserve">
+    <value>Do you really want to delete this participant? Their data will be archived.</value>
+  </data>
+  <data name="DeleteConfirmation_Primary" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteConfirmation_Close" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/ViewModels/Configuration/ConfigurationPageViewModel.cs
+++ b/ViewModels/Configuration/ConfigurationPageViewModel.cs
@@ -54,13 +54,15 @@ namespace StroopApp.ViewModels.Configuration
 
             if (_settings.CurrentProfile == null)
             {
-                ShowErrorDialog("Veuillez sélectionner un profil d'expérience.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_SelectProfile"] ?? "");
                 return;
             }
 
             if (_settings.Participant == null)
             {
-                ShowErrorDialog("Veuillez sélectionner un participant.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_SelectParticipant"] ?? "");
                 return;
             }
 

--- a/ViewModels/Configuration/Participant/ParticipantEditorViewModel.cs
+++ b/ViewModels/Configuration/Participant/ParticipantEditorViewModel.cs
@@ -100,12 +100,14 @@ namespace StroopApp.ViewModels.Configuration.Participant
                 double.IsNaN(Participant.Height.Value) ||
                 double.IsInfinity(Participant.Height.Value))
             {
-                ShowErrorDialog("Veuillez remplir correctement tous les champs obligatoires.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_ParticipantFieldsInvalid"] ?? "");
                 return;
             }
             if (Participants.Any(p => p.Id == Participant.Id && p != Participant))
             {
-                ShowErrorDialog("Cet identifiant est déjà utilisé pour un autre participant");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_DuplicateParticipantId"] ?? "");
                 return;
             }
 

--- a/ViewModels/Configuration/Participant/ParticipantManagementViewModel.cs
+++ b/ViewModels/Configuration/Participant/ParticipantManagementViewModel.cs
@@ -111,7 +111,8 @@ namespace StroopApp.ViewModels.Configuration.Participant
         {
             if (SelectedParticipant == null)
             {
-                ShowErrorDialog("Veuillez sélectionner un participant à modifier !");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_SelectParticipantToModify"] ?? "");
                 return;
             }
             var viewModel = new ParticipantEditorViewModel(SelectedParticipant, Participants, _participantService);
@@ -131,16 +132,18 @@ namespace StroopApp.ViewModels.Configuration.Participant
         {
             if (SelectedParticipant == null)
             {
-                ShowErrorDialog("Veuillez sélectionner un participant à supprimer !");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_SelectParticipantToDelete"] ?? "");
                 return;
             }
 
+            var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
             var dlg = new ContentDialog
             {
-                Title = "Confirmation de suppression",
-                Content = "Voulez-vous vraiment supprimer ce participant ? Ses données seront archivées.",
-                PrimaryButtonText = "Supprimer",
-                CloseButtonText = "Annuler"
+                Title = loc?["DeleteConfirmation_Title"],
+                Content = loc?["DeleteConfirmation_Message"],
+                PrimaryButtonText = loc?["DeleteConfirmation_Primary"],
+                CloseButtonText = loc?["DeleteConfirmation_Close"]
             };
             if (await dlg.ShowAsync() != ContentDialogResult.Primary)
                 return;

--- a/ViewModels/Configuration/Profile/ProfileEditorViewModel.cs
+++ b/ViewModels/Configuration/Profile/ProfileEditorViewModel.cs
@@ -111,38 +111,44 @@ namespace StroopApp.ViewModels.Configuration.Profile
         {
             if (string.IsNullOrWhiteSpace(Profile.ProfileName))
             {
-                ShowErrorDialog("Le nom du profil ne peut pas être vide ou contenir uniquement des espaces.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_ProfileNameEmpty"] ?? "");
                 return;
             }
 
             if (Profiles.Any(p => p.Id != Profile.Id && p.ProfileName == Profile.ProfileName))
             {
-                ShowErrorDialog("Un profil avec ce nom existe déjà. Veuillez choisir un autre nom.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_ProfileNameExists"] ?? "");
                 return;
             }
 
             if (Profile.WordDuration <= 0 || Profile.TaskDuration % Profile.WordDuration != 0)
             {
-                ShowErrorDialog("La durée du mot doit être positive et TaskDuration doit être divisible par WordDuration.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_WordDurationInvalid"] ?? "");
                 return;
             }
 
             int wordNumber = Profile.TaskDuration / Profile.WordDuration;
             if (Profile.GroupSize <= 0 || wordNumber % Profile.GroupSize != 0)
             {
-                ShowErrorDialog("La taille du groupe doit être positive et diviser le nombre de mots.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_GroupSizeInvalid"] ?? "");
                 return;
             }
 
             if (Profile.AmorceDuration == 0 && Profile.IsAmorce)
             {
-                ShowErrorDialog("Le temps d'amorce est doit être supérieur à 0 !");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_AmorceTimeInvalid"] ?? "");
                 return;
             }
 
             if (Profile.MaxReactionTime <= 0)
             {
-                ShowErrorDialog("Le temps de réaction maximum doit être positif.");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_MaxReactionInvalid"] ?? "");
                 return;
             }
 

--- a/ViewModels/Configuration/Profile/ProfileManagementViewModel.cs
+++ b/ViewModels/Configuration/Profile/ProfileManagementViewModel.cs
@@ -74,7 +74,8 @@ namespace StroopApp.ViewModels.Configuration.Profile
         {
             if (CurrentProfile == null)
             {
-                ShowErrorDialog("Veuillez sélectionner un profil à modifier !");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_SelectProfileToModify"] ?? "");
                 return;
             }
             var viewModel = new ProfileEditorViewModel(CurrentProfile, Profiles, _profileService);
@@ -95,7 +96,8 @@ namespace StroopApp.ViewModels.Configuration.Profile
         {
             if (CurrentProfile == null)
             {
-                ShowErrorDialog("Veuillez sélectionner un profil à supprimer !");
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+                ShowErrorDialog(loc?["Error_SelectProfileToDelete"] ?? "");
                 return;
             }
             int currentIndex = Profiles.IndexOf(_currentProfile);

--- a/ViewModels/Experiment/Experimenter/EndExperimentViewModel.cs
+++ b/ViewModels/Experiment/Experimenter/EndExperimentViewModel.cs
@@ -75,8 +75,9 @@ namespace StroopApp.ViewModels.Experiment.Experimenter
             RestartCommand = new RelayCommand(Restart);
             QuitCommand = new RelayCommand(Quit);
             Blocks = Settings.ExperimentContext.Blocks;
-            CurrentParticipant = "Participant n° " + Settings.Participant.Id.ToString();
-            CurrentProfile = "Tâche : " + Settings.CurrentProfile.ProfileName;
+            var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+            CurrentParticipant = string.Format(loc?["EndExperiment_CurrentParticipant"] ?? "Participant {0}", Settings.Participant.Id);
+            CurrentProfile = string.Format(loc?["EndExperiment_CurrentProfile"] ?? "Task: {0}", Settings.CurrentProfile.ProfileName);
             UpdateBlock();
         }
 
@@ -94,7 +95,7 @@ namespace StroopApp.ViewModels.Experiment.Experimenter
                     DataLabelsPaint = new SolidColorPaint(SKColors.Black),
                     DataLabelsFormatter = point =>
                 point.Coordinate.PrimaryValue.Equals(null)
-                    ? "Aucune réponse"
+                    ? (App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings)?["Column_NoResponse"]
                     : point.Coordinate.PrimaryValue.ToString("N0"),
                     Mapping = (point, index) => new Coordinate(
                         point.TrialNumber-1,

--- a/ViewModels/Experiment/Experimenter/LiveReactionTimeViewModel.cs
+++ b/ViewModels/Experiment/Experimenter/LiveReactionTimeViewModel.cs
@@ -29,10 +29,11 @@ namespace StroopApp.ViewModels.Experiment.Experimenter
                 .Skip(start - 1).Take(end - start + 1)
                 .Where(p => p.ReactionTime.HasValue && !double.IsNaN(p.ReactionTime.Value))
                 .Select(p => p.ReactionTime.Value);
-            GroupAverageLabel = $"Moyenne pour les mots {start} – {end} :";
+            var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+            GroupAverageLabel = string.Format(loc?["LiveAverage_Label"] ?? "", start, end);
             GroupAverageValue = group.Any()
-                ? $"{group.Average():N0} ms"
-                : "Aucune donnée valide";
+                ? $"{group.Average():N0} ms"
+                : loc?["LiveAverage_NoData"];
             OnPropertyChanged(nameof(GroupAverageLabel));
             OnPropertyChanged(nameof(GroupAverageValue));
         }

--- a/Views/Configuration/ConfigurationPage.xaml
+++ b/Views/Configuration/ConfigurationPage.xaml
@@ -5,7 +5,7 @@
       xmlns:viewsProfile="clr-namespace:StroopApp.Views.Profile"
       xmlns:viewsKeyMapping="clr-namespace:StroopApp.Views.KeyMapping"
       xmlns:viewsParticipant="clr-namespace:StroopApp.Views.Participant"
-      Title="Configuration de l'expérience">
+      Title="{Binding Source={StaticResource Loc}, Path=[ConfigPage_Title]}">
     <Grid x:Name="MainGrid"
           Margin="12">
         <Grid.RowDefinitions>
@@ -19,7 +19,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
-                   Text="Configuration des paramètres de l'expérience"
+                   Text="{Binding Source={StaticResource Loc}, Path=[ConfigPage_Title]}"
                    Style="{DynamicResource HeaderTextBlockStyle}"
                    HorizontalAlignment="Left"
                    Margin="0,0,0,12" />
@@ -33,7 +33,7 @@
         </Grid>
         <StackPanel Grid.Row="7"
                     HorizontalAlignment="Center">
-            <Button Content="Lancer l'expérience"
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_LaunchExperiment]}"
                     Style="{DynamicResource AccentButtonStyle}"
                     Command="{Binding LaunchExperimentCommand}" />
         </StackPanel>

--- a/Views/ExperimentWindow.xaml
+++ b/Views/ExperimentWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:StroopApp.Views"
         xmlns:ui="http://schemas.modernwpf.com/2019"
         mc:Ignorable="d"
-        Title="" Height="450" Width="800"
+        Title="{Binding Source={StaticResource Loc}, Path=[ExperimentWindow_Title]}" Height="450" Width="800"
         ui:WindowHelper.UseModernWindowStyle="True"
         Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
         WindowState="Maximized">

--- a/Views/ParticipantWindow.xaml
+++ b/Views/ParticipantWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="StroopApp.Views.ParticipantWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="ParticipantWindow" Height="450" Width="800"
+        Title="{Binding Source={StaticResource Loc}, Path=[ParticipantWindow_Title]}" Height="450" Width="800"
         Background="Black">
     <Window.Icon>
         <DrawingImage/>


### PR DESCRIPTION
## Summary
- create new localized string resources for buttons, dialogs and errors
- switch various windows and view models to use the `Loc` resource
- set the default UI culture to English on startup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850732bbef4832f9b2a8338b95c70ed