### PR TITLE
Partial internationalization

### DIFF
--- a/StroopApp/Resources/Strings.fr.resx
+++ b/StroopApp/Resources/Strings.fr.resx
@@ -220,4 +220,204 @@
   <data name="Menu_Languages" xml:space="preserve">
     <value>Langues</value>
   </data>
+<data name="ExportFolderSelector_Title" xml:space="preserve">
+  <value>Choix du dossier des résultats</value>
+</data>
+<data name="ExportFolderSelector_Description" xml:space="preserve">
+  <value>Sélectionnez le dossier d'exportation des résultats.</value>
+</data>
+<data name="ExportFolderSelector_PathLabel" xml:space="preserve">
+  <value>Dossier des résultats :</value>
+</data>
+<data name="Button_Browse" xml:space="preserve">
+  <value>Parcourir</value>
+</data>
+<data name="ParticipantManagement_Title" xml:space="preserve">
+  <value>Choix du participant</value>
+</data>
+<data name="ParticipantManagement_Description" xml:space="preserve">
+  <value>Sélectionnez un participant pour lancer l'expérience.</value>
+</data>
+<data name="Button_Create" xml:space="preserve">
+  <value>Créer</value>
+</data>
+<data name="Button_Modify" xml:space="preserve">
+  <value>Modifier</value>
+</data>
+<data name="Button_Delete" xml:space="preserve">
+  <value>Supprimer</value>
+</data>
+<data name="Search_Placeholder" xml:space="preserve">
+  <value>Rechercher...</value>
+</data>
+<data name="ParticipantEditorWindow_Title" xml:space="preserve">
+  <value>Modification du participant</value>
+</data>
+<data name="Field_ID" xml:space="preserve">
+  <value>ID</value>
+</data>
+<data name="Field_Age" xml:space="preserve">
+  <value>Âge</value>
+</data>
+<data name="Field_Weight" xml:space="preserve">
+  <value>Poids (kg)</value>
+</data>
+<data name="Field_Height" xml:space="preserve">
+  <value>Taille (cm)</value>
+</data>
+<data name="Field_Sex" xml:space="preserve">
+  <value>Sexe</value>
+</data>
+<data name="Field_Gender" xml:space="preserve">
+  <value>Genre</value>
+</data>
+<data name="Button_Cancel" xml:space="preserve">
+  <value>Annuler</value>
+</data>
+<data name="Button_Save" xml:space="preserve">
+  <value>Enregistrer</value>
+</data>
+<data name="ProfileManagement_Title" xml:space="preserve">
+  <value>Choix du profil de l'expérience</value>
+</data>
+<data name="ProfileManagement_Description" xml:space="preserve">
+  <value>Sélectionnez le profil à utiliser pour configurer votre expérience.</value>
+</data>
+<data name="ProfileManagement_DetailsTitle" xml:space="preserve">
+  <value>Détails du profil sélectionné</value>
+</data>
+<data name="Header_Congruence" xml:space="preserve">
+  <value>Congruence (%)</value>
+</data>
+<data name="Tooltip_Congruence" xml:space="preserve">
+  <value>Définit la proportion de mots congruents dans le bloc. Un mot est congruent lorsque sa signification correspond à sa couleur (ex. le mot Rouge écrit en rouge). Exemple : 25 % = 75 % d’incongruents, 25 % de congruents.</value>
+</data>
+<data name="Header_Switch" xml:space="preserve">
+  <value>Switch (%)</value>
+</data>
+<data name="Tooltip_Switch" xml:space="preserve">
+  <value>Définit la fréquence de changement de forme d’amorce entre deux essais. Un switch correspond à un passage d’un carré à un rond, ou inversement. Exemple : 100 % = alternance à chaque essai, 0 % = toujours la même forme.</value>
+</data>
+<data name="Header_Hours" xml:space="preserve">
+  <value>Heures</value>
+</data>
+<data name="Header_Minutes" xml:space="preserve">
+  <value>Minutes</value>
+</data>
+<data name="Header_Seconds" xml:space="preserve">
+  <value>Secondes</value>
+</data>
+<data name="Header_MaxReactionTime" xml:space="preserve">
+  <value>Temps de réaction max (ms)</value>
+</data>
+<data name="Header_WordDuration" xml:space="preserve">
+  <value>Durée par mot (ms)</value>
+</data>
+<data name="ProfileEditorWindow_Title" xml:space="preserve">
+  <value>Modification du profil</value>
+</data>
+<data name="Field_ProfileName" xml:space="preserve">
+  <value>Nom du profil</value>
+</data>
+<data name="Check_AddPrime" xml:space="preserve">
+  <value>Ajouter une amorce</value>
+</data>
+<data name="Label_CalculationMode" xml:space="preserve">
+  <value>Mode de calcul</value>
+</data>
+<data name="Radio_TaskDuration" xml:space="preserve">
+  <value>En fonction de la durée de la tâche</value>
+</data>
+<data name="Radio_WordCount" xml:space="preserve">
+  <value>En fonction du nombre de mots</value>
+</data>
+<data name="Field_GroupSize" xml:space="preserve">
+  <value>Taille du groupe</value>
+</data>
+<data name="Field_WordCount" xml:space="preserve">
+  <value>Nombre de mots</value>
+</data>
+<data name="KeyMapping_Title" xml:space="preserve">
+  <value>Choix des touches</value>
+</data>
+<data name="KeyMapping_Description" xml:space="preserve">
+  <value>Sélectionnez les touches à associer aux couleurs.</value>
+</data>
+<data name="Label_KeyRed" xml:space="preserve">
+  <value>Touche associée à la couleur rouge :</value>
+</data>
+<data name="Label_KeyBlue" xml:space="preserve">
+  <value>Touche associée à la couleur bleue :</value>
+</data>
+<data name="Label_KeyGreen" xml:space="preserve">
+  <value>Touche associée à la couleur verte :</value>
+</data>
+<data name="Label_KeyYellow" xml:space="preserve">
+  <value>Touche associée à la couleur jaune :</value>
+</data>
+<data name="Button_Edit" xml:space="preserve">
+  <value>Modifier</value>
+</data>
+<data name="KeyMapping_Prompt" xml:space="preserve">
+  <value>Appuyez sur une touche pour définir le mapping. Appuyez sur Échap pour annuler.</value>
+</data>
+<data name="KeyMapping_ErrorKeyUsed" xml:space="preserve">
+  <value>Cette touche est déjà utilisée. Veuillez choisir une autre touche.</value>
+</data>
+<data name="KeyMapping_DialogTitle" xml:space="preserve">
+  <value>Modification du mapping pour {0}</value>
+</data>
+<data name="ExportFolderDialog_Description" xml:space="preserve">
+  <value>Sélectionner le dossier d’exportation pour vos résultats</value>
+</data>
+<data name="Dashboard_Title" xml:space="preserve">
+  <value>Tableau de bord de l'expérience en cours</value>
+</data>
+<data name="Progress_Title" xml:space="preserve">
+  <value>Avancement</value>
+</data>
+<data name="ParticipantDetails_Title" xml:space="preserve">
+  <value>Détails du participant</value>
+</data>
+<data name="ExperimentDetails_Title" xml:space="preserve">
+  <value>Détails de l'expérience</value>
+</data>
+<data name="EndExperiment_BlockFinished" xml:space="preserve">
+  <value>Bloc terminé</value>
+</data>
+<data name="EndExperiment_BlockSummary" xml:space="preserve">
+  <value>Résumé des blocs</value>
+</data>
+<data name="Button_Continue" xml:space="preserve">
+  <value>Relancer</value>
+</data>
+<data name="Button_NewExperiment" xml:space="preserve">
+  <value>Nouvelle expérience</value>
+</data>
+<data name="Button_Quit" xml:space="preserve">
+  <value>Quitter l'application</value>
+</data>
+<data name="EndInstructions_Title" xml:space="preserve">
+  <value>Fin de l'expérience</value>
+</data>
+<data name="EndInstructions_Message" xml:space="preserve">
+  <value>Félicitations ! Vous avez terminé l'expérience.</value>
+</data>
+<data name="Reaction_None" xml:space="preserve">
+  <value>Aucune réponse</value>
+</data>
+<data name="Reaction_Correct" xml:space="preserve">
+  <value>Correct</value>
+</data>
+<data name="Reaction_Incorrect" xml:space="preserve">
+  <value>Incorrect</value>
+</data>
+<data name="GraphsView_Title" xml:space="preserve">
+  <value>Suivi de l'expérience</value>
+</data>
+<data name="Dialog_OK" xml:space="preserve">
+  <value>OK</value>
+</data>
+<data name="Header_FixationDuration" xml:space="preserve"><value>Durée de fixation (ms)</value></data>
+<data name="Header_PrimeDuration" xml:space="preserve"><value>Durée d'amorce (ms)</value></data>
 </root>

--- a/StroopApp/Resources/Strings.resx
+++ b/StroopApp/Resources/Strings.resx
@@ -220,4 +220,204 @@
   <data name="Menu_Languages" xml:space="preserve">
     <value>Languages</value>
   </data>
+<data name="ExportFolderSelector_Title" xml:space="preserve">
+  <value>Results folder selection</value>
+</data>
+<data name="ExportFolderSelector_Description" xml:space="preserve">
+  <value>Select the export folder for the results.</value>
+</data>
+<data name="ExportFolderSelector_PathLabel" xml:space="preserve">
+  <value>Results folder:</value>
+</data>
+<data name="Button_Browse" xml:space="preserve">
+  <value>Browse</value>
+</data>
+<data name="ParticipantManagement_Title" xml:space="preserve">
+  <value>Select participant</value>
+</data>
+<data name="ParticipantManagement_Description" xml:space="preserve">
+  <value>Select a participant to start the experiment.</value>
+</data>
+<data name="Button_Create" xml:space="preserve">
+  <value>Create</value>
+</data>
+<data name="Button_Modify" xml:space="preserve">
+  <value>Edit</value>
+</data>
+<data name="Button_Delete" xml:space="preserve">
+  <value>Delete</value>
+</data>
+<data name="Search_Placeholder" xml:space="preserve">
+  <value>Search...</value>
+</data>
+<data name="ParticipantEditorWindow_Title" xml:space="preserve">
+  <value>Edit participant</value>
+</data>
+<data name="Field_ID" xml:space="preserve">
+  <value>ID</value>
+</data>
+<data name="Field_Age" xml:space="preserve">
+  <value>Age</value>
+</data>
+<data name="Field_Weight" xml:space="preserve">
+  <value>Weight (kg)</value>
+</data>
+<data name="Field_Height" xml:space="preserve">
+  <value>Height (cm)</value>
+</data>
+<data name="Field_Sex" xml:space="preserve">
+  <value>Sex</value>
+</data>
+<data name="Field_Gender" xml:space="preserve">
+  <value>Gender</value>
+</data>
+<data name="Button_Cancel" xml:space="preserve">
+  <value>Cancel</value>
+</data>
+<data name="Button_Save" xml:space="preserve">
+  <value>Save</value>
+</data>
+<data name="ProfileManagement_Title" xml:space="preserve">
+  <value>Select task profile</value>
+</data>
+<data name="ProfileManagement_Description" xml:space="preserve">
+  <value>Select the profile to configure your experiment.</value>
+</data>
+<data name="ProfileManagement_DetailsTitle" xml:space="preserve">
+  <value>Selected profile details</value>
+</data>
+<data name="Header_Congruence" xml:space="preserve">
+  <value>Congruence (%)</value>
+</data>
+<data name="Tooltip_Congruence" xml:space="preserve">
+  <value>Defines the proportion of congruent words in the block. A word is congruent when its meaning matches its color (e.g. the word Red written in red). Example: 25% = 75% incongruent, 25% congruent.</value>
+</data>
+<data name="Header_Switch" xml:space="preserve">
+  <value>Switch (%)</value>
+</data>
+<data name="Tooltip_Switch" xml:space="preserve">
+  <value>Defines how often the prime shape changes between two trials. A switch is a transition from square to circle or vice versa. Example: 100% = alternation each trial, 0% = always the same shape.</value>
+</data>
+<data name="Header_Hours" xml:space="preserve">
+  <value>Hours</value>
+</data>
+<data name="Header_Minutes" xml:space="preserve">
+  <value>Minutes</value>
+</data>
+<data name="Header_Seconds" xml:space="preserve">
+  <value>Seconds</value>
+</data>
+<data name="Header_MaxReactionTime" xml:space="preserve">
+  <value>Max reaction time (ms)</value>
+</data>
+<data name="Header_WordDuration" xml:space="preserve">
+  <value>Word duration (ms)</value>
+</data>
+<data name="ProfileEditorWindow_Title" xml:space="preserve">
+  <value>Edit profile</value>
+</data>
+<data name="Field_ProfileName" xml:space="preserve">
+  <value>Profile name</value>
+</data>
+<data name="Check_AddPrime" xml:space="preserve">
+  <value>Add prime</value>
+</data>
+<data name="Label_CalculationMode" xml:space="preserve">
+  <value>Calculation mode</value>
+</data>
+<data name="Radio_TaskDuration" xml:space="preserve">
+  <value>Based on task duration</value>
+</data>
+<data name="Radio_WordCount" xml:space="preserve">
+  <value>Based on word count</value>
+</data>
+<data name="Field_GroupSize" xml:space="preserve">
+  <value>Group size</value>
+</data>
+<data name="Field_WordCount" xml:space="preserve">
+  <value>Word count</value>
+</data>
+<data name="KeyMapping_Title" xml:space="preserve">
+  <value>Key mapping</value>
+</data>
+<data name="KeyMapping_Description" xml:space="preserve">
+  <value>Select the keys associated with the colors.</value>
+</data>
+<data name="Label_KeyRed" xml:space="preserve">
+  <value>Key associated with the red color:</value>
+</data>
+<data name="Label_KeyBlue" xml:space="preserve">
+  <value>Key associated with the blue color:</value>
+</data>
+<data name="Label_KeyGreen" xml:space="preserve">
+  <value>Key associated with the green color:</value>
+</data>
+<data name="Label_KeyYellow" xml:space="preserve">
+  <value>Key associated with the yellow color:</value>
+</data>
+<data name="Button_Edit" xml:space="preserve">
+  <value>Edit</value>
+</data>
+<data name="KeyMapping_Prompt" xml:space="preserve">
+  <value>Press a key to define the mapping. Press Esc to cancel.</value>
+</data>
+<data name="KeyMapping_ErrorKeyUsed" xml:space="preserve">
+  <value>This key is already used. Please choose another one.</value>
+</data>
+<data name="KeyMapping_DialogTitle" xml:space="preserve">
+  <value>Edit mapping for {0}</value>
+</data>
+<data name="ExportFolderDialog_Description" xml:space="preserve">
+  <value>Select the export folder for your results</value>
+</data>
+<data name="Dashboard_Title" xml:space="preserve">
+  <value>Current experiment dashboard</value>
+</data>
+<data name="Progress_Title" xml:space="preserve">
+  <value>Progress</value>
+</data>
+<data name="ParticipantDetails_Title" xml:space="preserve">
+  <value>Participant details</value>
+</data>
+<data name="ExperimentDetails_Title" xml:space="preserve">
+  <value>Experiment details</value>
+</data>
+<data name="EndExperiment_BlockFinished" xml:space="preserve">
+  <value>Block completed</value>
+</data>
+<data name="EndExperiment_BlockSummary" xml:space="preserve">
+  <value>Block summary</value>
+</data>
+<data name="Button_Continue" xml:space="preserve">
+  <value>Continue</value>
+</data>
+<data name="Button_NewExperiment" xml:space="preserve">
+  <value>New experiment</value>
+</data>
+<data name="Button_Quit" xml:space="preserve">
+  <value>Quit application</value>
+</data>
+<data name="EndInstructions_Title" xml:space="preserve">
+  <value>End of experiment</value>
+</data>
+<data name="EndInstructions_Message" xml:space="preserve">
+  <value>Congratulations! You have completed the experiment.</value>
+</data>
+<data name="Reaction_None" xml:space="preserve">
+  <value>No response</value>
+</data>
+<data name="Reaction_Correct" xml:space="preserve">
+  <value>Correct</value>
+</data>
+<data name="Reaction_Incorrect" xml:space="preserve">
+  <value>Incorrect</value>
+</data>
+<data name="GraphsView_Title" xml:space="preserve">
+  <value>Experiment tracking</value>
+</data>
+<data name="Dialog_OK" xml:space="preserve">
+  <value>OK</value>
+</data>
+<data name="Header_FixationDuration" xml:space="preserve"><value>Fixation duration (ms)</value></data>
+<data name="Header_PrimeDuration" xml:space="preserve"><value>Prime duration (ms)</value></data>
 </root>

--- a/ViewModels/Configuration/ExportFolderSelectorViewModel.cs
+++ b/ViewModels/Configuration/ExportFolderSelectorViewModel.cs
@@ -27,9 +27,10 @@ namespace StroopApp.ViewModels.Configuration
 
             BrowseCommand = new RelayCommand(() =>
             {
+                var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
                 var dlg = new VistaFolderBrowserDialog
                 {
-                    Description = "Sélectionner le dossier d’exportation pour vos résultats",
+                    Description = loc?["ExportFolderDialog_Description"],
                     SelectedPath = Settings.ExportFolderPath
                 };
                 if (dlg.ShowDialog() == true)

--- a/ViewModels/Configuration/KeyMappingViewModel.cs
+++ b/ViewModels/Configuration/KeyMappingViewModel.cs
@@ -86,7 +86,8 @@ namespace StroopApp.ViewModels.Configuration
         {
             StartEditing(color);
 
-            string originalMessage = "Appuyez sur une touche pour définir le mapping. Appuyez sur Échap pour annuler.";
+            var loc = App.Current.Resources["Loc"] as StroopApp.Core.LocalizedStrings;
+            string originalMessage = loc?["KeyMapping_Prompt"] ?? string.Empty;
             var originalText = new TextBlock
             {
                 Text = originalMessage,
@@ -109,7 +110,7 @@ namespace StroopApp.ViewModels.Configuration
             };
             var errorText = new TextBlock
             {
-                Text = "Cette touche est déjà utilisée. Veuillez choisir une autre touche.",
+                Text = loc?["KeyMapping_ErrorKeyUsed"],
                 Foreground = new SolidColorBrush(Colors.Red),
                 Margin = new Thickness(8, 0, 0, 0),
                 VerticalAlignment = VerticalAlignment.Center
@@ -123,7 +124,7 @@ namespace StroopApp.ViewModels.Configuration
 
             var dialog = new ContentDialog
             {
-                Title = $"Modification du mapping pour {color}",
+                Title = string.Format(loc?["KeyMapping_DialogTitle"] ?? "{0}", color),
                 Content = grid,
                 PrimaryButtonText = string.Empty,
                 SecondaryButtonText = string.Empty

--- a/Views/Configuration/ExportFolderSelectorView.xaml
+++ b/Views/Configuration/ExportFolderSelectorView.xaml
@@ -8,9 +8,9 @@
             BorderThickness="0.5"
             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
         <ui:SimpleStackPanel Spacing="12" VerticalAlignment="Stretch">
-            <TextBlock Text="Choix du dossier des résultats"
-                   Style="{StaticResource TitleTextBlockStyle}" />
-            <TextBlock Text="Sélectionnez le dossier d'exportation des résultats." />
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ExportFolderSelector_Title]}"
+                       Style="{StaticResource TitleTextBlockStyle}" />
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ExportFolderSelector_Description]}" />
             <Grid Grid.Column="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -18,7 +18,7 @@
                 </Grid.RowDefinitions>
                 <!-- Header simple -->
                 <TextBlock Grid.Row="0"
-                           Text="Touche associée à la couleur rouge :"
+                           Text="{Binding Source={StaticResource Loc}, Path=[ExportFolderSelector_PathLabel]}"
                            Style="{DynamicResource BodyTextBlockStyle}"
                            HorizontalAlignment="Left"
                            Margin="0,0,0,4" />
@@ -37,7 +37,7 @@
                              Height="16"
                              VerticalAlignment="Center"
                              Margin="0,0,8,0" />
-                    <Button Content="Parcourir"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Browse]}"
                             Grid.Column="1"
                             Command="{Binding BrowseCommand}"
                             VerticalAlignment="Center"

--- a/Views/Configuration/KeyMapping/KeyMappingView.xaml
+++ b/Views/Configuration/KeyMapping/KeyMappingView.xaml
@@ -21,9 +21,9 @@
         <ui:SimpleStackPanel Spacing="10"
                              VerticalAlignment="Center">
             <!-- Titre et description -->
-            <TextBlock Text="Choix des touches"
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[KeyMapping_Title]}"
                        Style="{StaticResource TitleTextBlockStyle}" />
-            <TextBlock Text="Sélectionnez les touches à associer aux couleurs." />
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[KeyMapping_Description]}" />
             <!-- Grille à 4 colonnes pour les 4 couleurs -->
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -40,7 +40,7 @@
                     </Grid.RowDefinitions>
                     <!-- Header simple -->
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur rouge :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyRed]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -64,7 +64,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Rouge"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
                 <!-- Bleu -->
@@ -74,7 +74,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur bleue :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyBlue]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -97,7 +97,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Bleu"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
                 <!-- Vert -->
@@ -107,7 +107,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur verte :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyGreen]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -130,7 +130,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Vert"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
                 <!-- Jaune -->
@@ -140,7 +140,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur jaune :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyYellow]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -163,7 +163,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Jaune"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
             </Grid>

--- a/Views/Configuration/Participant/ParticipantEditorWindow.xaml
+++ b/Views/Configuration/Participant/ParticipantEditorWindow.xaml
@@ -2,14 +2,14 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="http://schemas.modernwpf.com/2019"
-        Title="Modification du participant"
+        Title="{Binding Source={StaticResource Loc}, Path=[ParticipantEditorWindow_Title]}"
         Width="450"
         Height="360"
         WindowStartupLocation="CenterScreen"
         ui:WindowHelper.UseModernWindowStyle="True">
     <ui:SimpleStackPanel Margin="12" Spacing="12">
-        <TextBlock Text="Modification du participant" Style="{StaticResource TitleTextBlockStyle}"/>
-        <ui:NumberBox ui:ControlHelper.Header="ID" 
+        <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ParticipantEditorWindow_Title]}" Style="{StaticResource TitleTextBlockStyle}"/>
+        <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_ID]}"
             Value="{Binding Participant.Id, Mode=TwoWay}" 
             Minimum="0" 
             SpinButtonPlacementMode="Inline"/>
@@ -21,17 +21,17 @@
                 <ColumnDefinition Width="6" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ui:NumberBox ui:ControlHelper.Header="Âge" 
+            <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Age]}"
                 Value="{Binding Participant.Age, Mode=TwoWay}" 
                 Minimum="0" 
                 Grid.Column="0"
                 SpinButtonPlacementMode="Inline"/>
-            <ui:NumberBox ui:ControlHelper.Header="Poids (kg)" 
+            <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Weight]}"
                 Value="{Binding Participant.Weight, Mode=TwoWay}" 
                 Minimum="0" 
                 Grid.Column="2"
                 SpinButtonPlacementMode="Inline"/>
-            <ui:NumberBox ui:ControlHelper.Header="Taille (cm)" 
+            <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Height]}"
                 Value="{Binding Participant.Height, Mode=TwoWay}" 
                 Minimum="0" 
                 Grid.Column="4"
@@ -43,19 +43,19 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <ComboBox Grid.Column="0"
-                      ui:ControlHelper.Header="Sexe"
+                      ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Sex]}"
                       ItemsSource="{Binding SexAssignedValues}"
                       SelectedItem="{Binding Participant.SexAssigned, Mode=TwoWay}"
                       Width="200"/>
             <ComboBox Grid.Column="1"
-                      ui:ControlHelper.Header="Genre"
+                      ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Gender]}"
                       ItemsSource="{Binding GenderValues}"
                       SelectedItem="{Binding Participant.Gender, Mode=TwoWay}"
                       Width="200"/>
         </Grid>
         <ui:SimpleStackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">
-            <Button Content="Annuler" Style="{StaticResource DefaultButtonStyle}" Command="{Binding CancelCommand}"/>
-            <Button Content="Enregistrer" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveCommand}"/>
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Cancel]}" Style="{StaticResource DefaultButtonStyle}" Command="{Binding CancelCommand}"/>
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Save]}" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveCommand}"/>
         </ui:SimpleStackPanel>
     </ui:SimpleStackPanel>
 </Window>

--- a/Views/Configuration/Participant/ParticipantManagementView.xaml
+++ b/Views/Configuration/Participant/ParticipantManagementView.xaml
@@ -25,7 +25,7 @@
             </Grid.RowDefinitions>
             <ui:SimpleStackPanel Grid.Row="0"
                                  Spacing="10">
-                <TextBlock Text="Choix du participant"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ParticipantManagement_Title]}"
                            Style="{StaticResource TitleTextBlockStyle}" />
                 <Grid HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
@@ -33,7 +33,7 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"
-                               Text="Sélectionnez un participant pour lancer l'expérience."
+                               Text="{Binding Source={StaticResource Loc}, Path=[ParticipantManagement_Description]}"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center" />
                     <ui:SimpleStackPanel Grid.Column="1"
@@ -62,7 +62,7 @@
                                              Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                              Padding="34,6,0,0" />
                                     <TextBlock IsHitTestVisible="False"
-                                               Text="Rechercher . . ."
+                                               Text="{Binding Source={StaticResource Loc}, Path=[Search_Placeholder]}"
                                                VerticalAlignment="Center"
                                                HorizontalAlignment="Left"
                                                Margin="34,0,0,0"
@@ -84,11 +84,11 @@
                                 </Grid>
                             </Grid>
                         </Border>
-                        <Button Content="Créer"
+                        <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Create]}"
                                 Command="{Binding CreateParticipantCommand}" />
-                        <Button Content="Modifier"
+                        <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Modify]}"
                                 Command="{Binding ModifyParticipantCommand}" />
-                        <Button Content="Supprimer"
+                        <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Delete]}"
                                 Command="{Binding DeleteParticipantCommand}"></Button>
                     </ui:SimpleStackPanel>
                 </Grid>

--- a/Views/Configuration/Profile/ProfileEditorWindow.xaml
+++ b/Views/Configuration/Profile/ProfileEditorWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:converters="clr-namespace:StroopApp.Converters"
         xmlns:ui="http://schemas.modernwpf.com/2019"
-        Title="Modification du profil"
+        Title="{Binding Source={StaticResource Loc}, Path=[ProfileEditorWindow_Title]}"
         Width="750"
         Height="850"
         WindowStartupLocation="CenterScreen"
@@ -18,7 +18,7 @@
     </Window.Resources>
     <ui:SimpleStackPanel Margin="16"
                          Spacing="16">
-        <TextBlock Text="Modification du profil"
+        <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileEditorWindow_Title]}"
                    Style="{StaticResource TitleTextBlockStyle}" />
         <Border Background="{DynamicResource SystemControlBackgroundAltMediumBrush}"
                 CornerRadius="8"
@@ -26,9 +26,9 @@
                 BorderThickness="0.5"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="12">
-                <TextBox ui:ControlHelper.Header="Nom du profil"
+                <TextBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_ProfileName]}"
                          Text="{Binding Profile.ProfileName, Mode=TwoWay}" />
-                <CheckBox Content="Ajouter une amorce"
+                <CheckBox Content="{Binding Source={StaticResource Loc}, Path=[Check_AddPrime]}"
                           IsChecked="{Binding Profile.IsAmorce}"
                           />
                 <Grid>
@@ -42,7 +42,7 @@
                         <RowDefinition Height="12" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <Slider ui:ControlHelper.Header="Pourcentage de switch"
+                    <Slider ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Switch] }"
                             Minimum="0"
                             Maximum="100"
                             LargeChange="5"
@@ -59,7 +59,7 @@
                                   Grid.Column="2"
                                   Grid.Row="0"
                                   IsEnabled="{Binding Profile.IsAmorce}"/>
-                    <Slider ui:ControlHelper.Header="Pourcentage de congruence"
+                    <Slider ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Congruence]}"
                             Minimum="0"
                             Maximum="100"
                             LargeChange="5"
@@ -93,17 +93,17 @@
                     <!-- En-têtes des colonnes -->
                     <TextBlock Grid.Row="0"
                                Grid.Column="0"
-                               Text="Durée du mot (ms)"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Header_WordDuration]}"
                                Width="120" />
                     <TextBlock Grid.Row="0"
                                Grid.Column="2"
-                               Text="Temps de réponse max (ms)" />
+                               Text="{Binding Source={StaticResource Loc}, Path=[Header_MaxReactionTime]}" />
                     <TextBlock Grid.Row="0"
                                Grid.Column="4"
-                               Text="Durée de fixation (ms)" />
+                               Text="{Binding Source={StaticResource Loc}, Path=[Header_FixationDuration]}" />
                     <TextBlock Grid.Row="0"
                                Grid.Column="6"
-                               Text="Durée d'amorce (ms)" />
+                               Text="{Binding Source={StaticResource Loc}, Path=[Header_PrimeDuration]}" />
                     <!-- Valeurs et signes alignés uniquement sur la ligne des inputs -->
                     <TextBox Grid.Row="2"
                              Grid.Column="0"
@@ -148,16 +148,16 @@
             </ui:SimpleStackPanel>
         </Border>
         <ui:SimpleStackPanel Spacing="16">
-            <TextBlock Text="Mode de calcul"
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Label_CalculationMode]}"
                        Style="{StaticResource SubtitleTextBlockStyle}" />
             <ui:SimpleStackPanel Orientation="Horizontal"
                                  Spacing="12">
-                <RadioButton Content="En fonction de la durée de la tâche"
+                <RadioButton Content="{Binding Source={StaticResource Loc}, Path=[Radio_TaskDuration]}"
                              GroupName="CalculationModeGroup"
                              IsChecked="{Binding Profile.CalculationMode,
                                          Converter={StaticResource CalculationModeToBooleanConverter},
                                          ConverterParameter=TaskDuration}" />
-                <RadioButton Content="En fonction du nombre de mots"
+                <RadioButton Content="{Binding Source={StaticResource Loc}, Path=[Radio_WordCount]}"
                              GroupName="CalculationModeGroup"
                              IsChecked="{Binding Profile.CalculationMode,
                                          Converter={StaticResource CalculationModeToBooleanConverter},
@@ -304,10 +304,10 @@
             <ui:SimpleStackPanel Orientation="Horizontal"
                                  HorizontalAlignment="Center"
                                  Spacing="12">
-                <Button Content="Annuler"
+                <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Cancel]}"
                         Style="{StaticResource DefaultButtonStyle}"
                         Command="{Binding CancelCommand}" />
-                <Button Content="Enregistrer"
+                <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Save]}"
                         Style="{StaticResource AccentButtonStyle}"
                         Command="{Binding SaveCommand}" />
             </ui:SimpleStackPanel>

--- a/Views/Configuration/Profile/ProfileManagementView.xaml
+++ b/Views/Configuration/Profile/ProfileManagementView.xaml
@@ -24,9 +24,9 @@
                 BorderThickness="0.5"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="10">
-                <TextBlock Text="Choix du profil de l'expérience"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileManagement_Title]}"
                            Style="{DynamicResource TitleTextBlockStyle}" />
-                <TextBlock Text="Sélectionnez le profil à utiliser pour configurer votre expérience."
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileManagement_Description]}"
                            Style="{DynamicResource CaptionTextBlockStyle}" />
                 <ui:SimpleStackPanel Orientation="Horizontal"
                                      HorizontalAlignment="Left"
@@ -37,13 +37,13 @@
                               SelectedItem="{Binding CurrentProfile}"
                               DisplayMemberPath="ProfileName"
                               Background="{DynamicResource SystemControlBackgroundAltHighBrush}" />
-                    <Button Content="Créer"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Create]}"
                             Command="{Binding CreateProfileCommand}"
                             Style="{DynamicResource DefaultButtonStyle}" />
-                    <Button Content="Modifier"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Modify]}"
                             Command="{Binding ModifyProfileCommand}"
                             Style="{DynamicResource DefaultButtonStyle}" />
-                    <Button Content="Supprimer"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Delete]}"
                             Command="{Binding DeleteProfileCommand}"
                             Style="{DynamicResource DefaultButtonStyle}" />
                 </ui:SimpleStackPanel>
@@ -56,7 +56,7 @@
                 BorderThickness="0.5"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="10">
-                <TextBlock Text="Détails du profil sélectionné"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileManagement_DetailsTitle]}"
                            Style="{DynamicResource TitleTextBlockStyle}" />
                 <Grid Margin="0">
                     <Grid.ColumnDefinitions>
@@ -77,7 +77,7 @@
                                                  Exemple : 25 % = 75 % d’incongruents, 25 % de congruents."
                                                  ToolTipService.Placement="Top"
                                                  ToolTipService.InitialShowDelay="100">
-                                <TextBlock Text="Congruence (%)" />
+                                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Congruence]}" />
                                 <TextBlock Text=""
                                            FontFamily="Segoe MDL2 Assets"
                                            FontSize="14"
@@ -97,7 +97,7 @@
                                                  Exemple : 100 % = alternance à chaque essai, 0 % = toujours la même forme."
                                                  ToolTipService.Placement="Top"
                                                  ToolTipService.InitialShowDelay="100">
-                                <TextBlock Text="Switch (%)" />
+                                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Switch]}" />
                                 <TextBlock Text=""
                                            FontFamily="Segoe MDL2 Assets"
                                            FontSize="14"
@@ -113,25 +113,25 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0"
-                                 ui:ControlHelper.Header="Heures"
+                                 ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Hours]}"
                                  Text="{Binding CurrentProfile.TaskDuration, Converter={StaticResource MillisecondsToHoursConverter}}"
                                  Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                         <TextBox Grid.Column="1"
                                  Text="{Binding CurrentProfile.TaskDuration, Converter={StaticResource MillisecondsToMinutesConverter}}"
-                                 ui:ControlHelper.Header="Minutes"
+                                 ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Minutes]}"
                                  Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                         <TextBox Grid.Column="2"
                                  Text="{Binding CurrentProfile.TaskDuration, Converter={StaticResource MillisecondsToSecondsConverter}}"
-                                 ui:ControlHelper.Header="Secondes"
+                                 ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Seconds]}"
                                  Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                     </Grid>
                     <TextBox Grid.Column="3"
                              Text="{Binding CurrentProfile.MaxReactionTime}"
-                             ui:ControlHelper.Header="Temps de réaction max (ms)"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_MaxReactionTime]}"
                              Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                     <TextBox Grid.Column="4"
                              Text="{Binding CurrentProfile.WordDuration}"
-                             ui:ControlHelper.Header="Durée par mot (ms)"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_WordDuration]}"
                              Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                 </Grid>
             </ui:SimpleStackPanel>


### PR DESCRIPTION
## Summary
- add EN/FR resource strings for several UI texts
- bind strings in some configuration views and editor windows
- localize key mapping view and export folder dialog
- support localization in view models

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519c3a5074832faa9a711b65fb0039