### PR TITLE
Bind UI text to resource files

### DIFF
--- a/StroopApp/Resources/Strings.fr.resx
+++ b/StroopApp/Resources/Strings.fr.resx
@@ -415,9 +415,18 @@
 <data name="GraphsView_Title" xml:space="preserve">
   <value>Suivi de l'expérience</value>
 </data>
-<data name="Dialog_OK" xml:space="preserve">
-  <value>OK</value>
-</data>
-<data name="Header_FixationDuration" xml:space="preserve"><value>Durée de fixation (ms)</value></data>
-<data name="Header_PrimeDuration" xml:space="preserve"><value>Durée d'amorce (ms)</value></data>
+  <data name="Dialog_OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Header_TrialDuration" xml:space="preserve"><value>Durée de l'essai (ms)</value></data>
+  <data name="Header_ParticipantId" xml:space="preserve"><value>ID du participant</value></data>
+  <data name="Header_Block" xml:space="preserve"><value>Bloc</value></data>
+  <data name="Header_Trials" xml:space="preserve"><value>Essais</value></data>
+  <data name="Header_Accuracy" xml:space="preserve"><value>Précision</value></data>
+  <data name="Header_MeanReactionTime" xml:space="preserve"><value>Temps moyen de réponse</value></data>
+  <data name="Header_StroopType" xml:space="preserve"><value>Type Stroop</value></data>
+  <data name="Toggle_On" xml:space="preserve"><value>Activé</value></data>
+  <data name="Toggle_Off" xml:space="preserve"><value>Désactivé</value></data>
+  <data name="Header_FixationDuration" xml:space="preserve"><value>Durée de fixation (ms)</value></data>
+  <data name="Header_PrimeDuration" xml:space="preserve"><value>Durée d'amorce (ms)</value></data>
 </root>

--- a/StroopApp/Resources/Strings.resx
+++ b/StroopApp/Resources/Strings.resx
@@ -415,9 +415,36 @@
 <data name="GraphsView_Title" xml:space="preserve">
   <value>Experiment tracking</value>
 </data>
-<data name="Dialog_OK" xml:space="preserve">
-  <value>OK</value>
-</data>
-<data name="Header_FixationDuration" xml:space="preserve"><value>Fixation duration (ms)</value></data>
-<data name="Header_PrimeDuration" xml:space="preserve"><value>Prime duration (ms)</value></data>
+  <data name="Dialog_OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Header_TrialDuration" xml:space="preserve">
+    <value>Trial duration (ms)</value>
+  </data>
+  <data name="Header_ParticipantId" xml:space="preserve">
+    <value>Participant ID</value>
+  </data>
+  <data name="Header_Block" xml:space="preserve">
+    <value>Block</value>
+  </data>
+  <data name="Header_Trials" xml:space="preserve">
+    <value>Trials</value>
+  </data>
+  <data name="Header_Accuracy" xml:space="preserve">
+    <value>Accuracy</value>
+  </data>
+  <data name="Header_MeanReactionTime" xml:space="preserve">
+    <value>Average response time</value>
+  </data>
+  <data name="Header_StroopType" xml:space="preserve">
+    <value>Stroop type</value>
+  </data>
+  <data name="Toggle_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="Toggle_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Header_FixationDuration" xml:space="preserve"><value>Fixation duration (ms)</value></data>
+  <data name="Header_PrimeDuration" xml:space="preserve"><value>Prime duration (ms)</value></data>
 </root>

--- a/StroopApp/Views/Configuration/ConfigurationPage.xaml
+++ b/StroopApp/Views/Configuration/ConfigurationPage.xaml
@@ -33,7 +33,7 @@
         </Grid>
         <StackPanel Grid.Row="7"
                     HorizontalAlignment="Center">
-            <Button Content="Lancer l'expérience"
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_LaunchExperiment]}"
                     Style="{DynamicResource AccentButtonStyle}"
                     Command="{Binding LaunchExperimentCommand}" />
         </StackPanel>

--- a/StroopApp/Views/Configuration/ExportFolderSelectorView.xaml
+++ b/StroopApp/Views/Configuration/ExportFolderSelectorView.xaml
@@ -8,9 +8,9 @@
             BorderThickness="0.5"
             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
         <ui:SimpleStackPanel Spacing="12" VerticalAlignment="Stretch">
-            <TextBlock Text="Choix du dossier des résultats"
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ExportFolderSelector_Title]}"
                    Style="{StaticResource TitleTextBlockStyle}" />
-            <TextBlock Text="Sélectionnez le dossier d'exportation des résultats." />
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ExportFolderSelector_Description]}" />
             <Grid Grid.Column="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -18,7 +18,7 @@
                 </Grid.RowDefinitions>
                 <!-- Header simple -->
                 <TextBlock Grid.Row="0"
-                           Text="Dossier d'exportation des résultats :"
+                           Text="{Binding Source={StaticResource Loc}, Path=[ExportFolderSelector_PathLabel]}"
                            Style="{DynamicResource BodyTextBlockStyle}"
                            HorizontalAlignment="Left"
                            Margin="0,0,0,4" />
@@ -37,7 +37,7 @@
                              Height="16"
                              VerticalAlignment="Center"
                              Margin="0,0,8,0" />
-                    <Button Content="Parcourir"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Browse]}"
                             Grid.Column="1"
                             Command="{Binding BrowseCommand}"
                             VerticalAlignment="Center"

--- a/StroopApp/Views/Configuration/KeyMapping/KeyMappingView.xaml
+++ b/StroopApp/Views/Configuration/KeyMapping/KeyMappingView.xaml
@@ -21,9 +21,9 @@
         <ui:SimpleStackPanel Spacing="10"
                              VerticalAlignment="Center">
             <!-- Titre et description -->
-            <TextBlock Text="Choix des touches"
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[KeyMapping_Title]}"
                        Style="{StaticResource TitleTextBlockStyle}" />
-            <TextBlock Text="Sélectionnez les touches à associer aux couleurs." />
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[KeyMapping_Description]}" />
             <!-- Grille à 4 colonnes pour les 4 couleurs -->
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -40,7 +40,7 @@
                     </Grid.RowDefinitions>
                     <!-- Header simple -->
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur rouge :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyRed]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -64,7 +64,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Rouge"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
                 <!-- Bleu -->
@@ -74,7 +74,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur bleue :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyBlue]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -97,7 +97,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Bleu"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
                 <!-- Vert -->
@@ -107,7 +107,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur verte :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyGreen]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -130,7 +130,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Vert"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
                 <!-- Jaune -->
@@ -140,7 +140,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0"
-                               Text="Touche associée à la couleur jaune :"
+                               Text="{Binding Source={StaticResource Loc}, Path=[Label_KeyYellow]}"
                                Style="{DynamicResource BodyTextBlockStyle}"
                                HorizontalAlignment="Left"
                                Margin="0,0,0,4" />
@@ -163,7 +163,7 @@
                                 Command="{Binding OpenKeyMappingEditorCommand}"
                                 CommandParameter="Jaune"
                                 VerticalAlignment="Center"
-                                Content="Modifier" />
+                                Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}" />
                     </Grid>
                 </Grid>
             </Grid>

--- a/StroopApp/Views/Configuration/Participant/ParticipantEditorWindow.xaml
+++ b/StroopApp/Views/Configuration/Participant/ParticipantEditorWindow.xaml
@@ -8,8 +8,8 @@
         WindowStartupLocation="CenterScreen"
         ui:WindowHelper.UseModernWindowStyle="True">
     <ui:SimpleStackPanel Margin="12" Spacing="12">
-        <TextBlock Text="Modification du participant" Style="{StaticResource TitleTextBlockStyle}"/>
-        <TextBox ui:ControlHelper.Header="ID" 
+        <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ParticipantEditorWindow_Title]}" Style="{StaticResource TitleTextBlockStyle}"/>
+        <TextBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_ID]}" 
             Text="{Binding Participant.Id, Mode=TwoWay}" />
         <Grid>
             <Grid.ColumnDefinitions>
@@ -19,17 +19,17 @@
                 <ColumnDefinition Width="6" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ui:NumberBox ui:ControlHelper.Header="Âge" 
+            <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Age]}" 
                 Value="{Binding Participant.Age, Mode=TwoWay}" 
                 Minimum="0" 
                 Grid.Column="0"
                 SpinButtonPlacementMode="Inline"/>
-            <ui:NumberBox ui:ControlHelper.Header="Poids (kg)" 
+            <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Weight]}" 
                 Value="{Binding Participant.Weight, Mode=TwoWay}" 
                 Minimum="0" 
                 Grid.Column="2"
                 SpinButtonPlacementMode="Inline"/>
-            <ui:NumberBox ui:ControlHelper.Header="Taille (cm)" 
+            <ui:NumberBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Height]}" 
                 Value="{Binding Participant.Height, Mode=TwoWay}" 
                 Minimum="0" 
                 Grid.Column="4"
@@ -41,19 +41,19 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <ComboBox Grid.Column="0"
-                      ui:ControlHelper.Header="Sexe"
+                      ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Sex]}"
                       ItemsSource="{Binding SexAssignedValues}"
                       SelectedItem="{Binding Participant.SexAssigned, Mode=TwoWay}"
                       Width="200"/>
             <ComboBox Grid.Column="1"
-                      ui:ControlHelper.Header="Genre"
+                      ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_Gender]}"
                       ItemsSource="{Binding GenderValues}"
                       SelectedItem="{Binding Participant.Gender, Mode=TwoWay}"
                       Width="200"/>
         </Grid>
         <ui:SimpleStackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">
-            <Button Content="Annuler" Style="{StaticResource DefaultButtonStyle}" Command="{Binding CancelCommand}"/>
-            <Button Content="Enregistrer" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveCommand}"/>
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Cancel]}" Style="{StaticResource DefaultButtonStyle}" Command="{Binding CancelCommand}"/>
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Save]}" Style="{StaticResource AccentButtonStyle}" Command="{Binding SaveCommand}"/>
         </ui:SimpleStackPanel>
     </ui:SimpleStackPanel>
 </Window>

--- a/StroopApp/Views/Configuration/Participant/ParticipantManagementView.xaml
+++ b/StroopApp/Views/Configuration/Participant/ParticipantManagementView.xaml
@@ -25,7 +25,7 @@
             </Grid.RowDefinitions>
             <ui:SimpleStackPanel Grid.Row="0"
                                  Spacing="10">
-                <TextBlock Text="Choix du participant"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ParticipantManagement_Title]}"
                            Style="{StaticResource TitleTextBlockStyle}" />
                 <Grid HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
@@ -33,7 +33,7 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"
-                               Text="Sélectionnez un participant pour lancer l'expérience."
+                               Text="{Binding Source={StaticResource Loc}, Path=[ParticipantManagement_Description]}"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center" />
                     <ui:SimpleStackPanel Grid.Column="1"
@@ -62,7 +62,7 @@
                                              Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                              Padding="34,6,0,0" />
                                     <TextBlock IsHitTestVisible="False"
-                                               Text="Rechercher . . ."
+                                               Text="{Binding Source={StaticResource Loc}, Path=[Search_Placeholder]}"
                                                VerticalAlignment="Center"
                                                HorizontalAlignment="Left"
                                                Margin="34,0,0,0"
@@ -84,11 +84,11 @@
                                 </Grid>
                             </Grid>
                         </Border>
-                        <Button Content="Créer"
+                        <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Create]}"
                                 Command="{Binding CreateParticipantCommand}" />
-                        <Button Content="Modifier"
+                        <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}"
                                 Command="{Binding ModifyParticipantCommand}" />
-                        <Button Content="Supprimer"
+                        <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Delete]}"
                                 Command="{Binding DeleteParticipantCommand}"></Button>
                     </ui:SimpleStackPanel>
                 </Grid>
@@ -106,22 +106,22 @@
                           ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <ListView.View>
                         <GridView>
-                            <GridViewColumn Header="ID"
+                            <GridViewColumn Header="{Binding Source={StaticResource Loc}, Path=[Field_ID]}"
                                             DisplayMemberBinding="{Binding Id}"
                                             Width="80" />
-                            <GridViewColumn Header="Âge"
+                            <GridViewColumn Header="{Binding Source={StaticResource Loc}, Path=[Field_Age]}"
                                             DisplayMemberBinding="{Binding Age}"
                                             Width="80" />
-                            <GridViewColumn Header="Taille (cm)"
+                            <GridViewColumn Header="{Binding Source={StaticResource Loc}, Path=[Field_Height]}"
                                             DisplayMemberBinding="{Binding Height}"
                                             Width="100" />
-                            <GridViewColumn Header="Poids (kg)"
+                            <GridViewColumn Header="{Binding Source={StaticResource Loc}, Path=[Field_Weight]}"
                                             DisplayMemberBinding="{Binding Weight}"
                                             Width="100" />
-                            <GridViewColumn Header="Sexe"
+                            <GridViewColumn Header="{Binding Source={StaticResource Loc}, Path=[Field_Sex]}"
                                             DisplayMemberBinding="{Binding SexAssigned}"
                                             Width="150" />
-                            <GridViewColumn Header="Genre"
+                            <GridViewColumn Header="{Binding Source={StaticResource Loc}, Path=[Field_Gender]}"
                                             DisplayMemberBinding="{Binding Gender}"
                                             Width="150" />
                             <GridViewColumn Header="Résultats"

--- a/StroopApp/Views/Configuration/Profile/ProfileEditorWindow.xaml
+++ b/StroopApp/Views/Configuration/Profile/ProfileEditorWindow.xaml
@@ -39,7 +39,7 @@
                       Grid.RowSpan="2">
             <ui:SimpleStackPanel Margin="16,16,16,64"
                                  Spacing="16">
-                <TextBlock Text="Modification du profil"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileEditorWindow_Title]}"
                            Style="{StaticResource TitleTextBlockStyle}" />
                 <Border Background="{DynamicResource SystemControlBackgroundAltMediumBrush}"
                         CornerRadius="8"
@@ -47,7 +47,7 @@
                         BorderThickness="0.5"
                         BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
                     <ui:SimpleStackPanel Spacing="12">
-                        <TextBox ui:ControlHelper.Header="Nom du profil"
+                        <TextBox ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Field_ProfileName]}"
                                  Text="{Binding Profile.ProfileName, Mode=TwoWay}" />
                         <Grid Margin="0,8,0,8">
                             <Grid.ColumnDefinitions>
@@ -55,7 +55,7 @@
                                 <ColumnDefinition Width="16" />
                                 <ColumnDefinition Width="0.3*" />
                             </Grid.ColumnDefinitions>
-                            <Slider ui:ControlHelper.Header="Pourcentage de congruence"
+                            <Slider ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Congruence]}"
                                     Minimum="0"
                                     Maximum="100"
                                     LargeChange="5"
@@ -88,16 +88,16 @@
                             <!-- En-têtes des colonnes -->
                             <TextBlock Grid.Row="0"
                                        Grid.Column="0"
-                                       Text="Durée de l'essai (ms)" />
+                                       Text="{Binding Source={StaticResource Loc}, Path=[Header_TrialDuration]}" />
                             <TextBlock Grid.Row="0"
                                        Grid.Column="2"
-                                       Text="Durée de fixation (ms)" />
+                                       Text="{Binding Source={StaticResource Loc}, Path=[Header_FixationDuration]}" />
                             <TextBlock Grid.Row="0"
                                        Grid.Column="4"
-                                       Text="Durée d'amorce (ms)" />
+                                       Text="{Binding Source={StaticResource Loc}, Path=[Header_PrimeDuration]}" />
                             <TextBlock Grid.Row="0"
                                        Grid.Column="6"
-                                       Text="Temps de réponse max (ms)" />
+                                       Text="{Binding Source={StaticResource Loc}, Path=[Header_MaxReactionTime]}" />
                             <!-- Valeurs et signes alignés uniquement sur la ligne des inputs -->
                             <TextBox Grid.Row="2"
                                      Grid.Column="0"
@@ -163,11 +163,11 @@
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="Activer l'amorce"
+                            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Check_AddPrime] }"
                                        VerticalAlignment="Center" />
                             <ui:ToggleSwitch IsOn="{Binding Profile.IsAmorce, Mode=TwoWay}"
-                                             OnContent="Activé"
-                                             OffContent="Désactivé"
+                                             OnContent="{Binding Source={StaticResource Loc}, Path=[Toggle_On]}"
+                                             OffContent="{Binding Source={StaticResource Loc}, Path=[Toggle_Off]}"
                                              VerticalAlignment="Center"
                                              Grid.Column="1"
                                              HorizontalAlignment="Right"
@@ -179,16 +179,16 @@
                                                      Visibility="{Binding DataContext.Profile.IsAmorce, ElementName=RootPanel, Converter={StaticResource BoolToVisibilityConverter}}" />
                 </ui:SimpleStackPanel>
                 <ui:SimpleStackPanel Spacing="16">
-                    <TextBlock Text="Mode de calcul"
+                    <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Label_CalculationMode]}"
                                Style="{StaticResource SubtitleTextBlockStyle}" />
                     <ui:SimpleStackPanel Orientation="Horizontal"
                                          Spacing="12">
-                        <RadioButton Content="En fonction de la durée de la tâche"
+                        <RadioButton Content="{Binding Source={StaticResource Loc}, Path=[Radio_TaskDuration]}"
                                      GroupName="CalculationModeGroup"
                                      IsChecked="{Binding Profile.CalculationMode,
                                          Converter={StaticResource CalculationModeToBooleanConverter},
                                          ConverterParameter=TaskDuration}" />
-                        <RadioButton Content="En fonction du nombre de mots"
+                        <RadioButton Content="{Binding Source={StaticResource Loc}, Path=[Radio_WordCount]}"
                                      GroupName="CalculationModeGroup"
                                      IsChecked="{Binding Profile.CalculationMode,
                                          Converter={StaticResource CalculationModeToBooleanConverter},
@@ -222,18 +222,18 @@
                                     <ColumnDefinition Width="12" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <ui:NumberBox Header="Heures"
+                                <ui:NumberBox Header="{Binding Source={StaticResource Loc}, Path=[Header_Hours]}"
                                               Value="{Binding Profile.Hours, Mode=TwoWay}"
                                               Minimum="0"
                                               SpinButtonPlacementMode="Inline"
                                               Grid.Column="0" />
-                                <ui:NumberBox Header="Minutes"
+                                <ui:NumberBox Header="{Binding Source={StaticResource Loc}, Path=[Header_Minutes]}"
                                               Value="{Binding Profile.Minutes, Mode=TwoWay}"
                                               Minimum="0"
                                               Maximum="59"
                                               SpinButtonPlacementMode="Inline"
                                               Grid.Column="2" />
-                                <ui:NumberBox Header="Secondes"
+                                <ui:NumberBox Header="{Binding Source={StaticResource Loc}, Path=[Header_Seconds]}"
                                               Value="{Binding Profile.Seconds, Mode=TwoWay}"
                                               Minimum="0"
                                               Maximum="59"
@@ -248,14 +248,14 @@
                                     <ColumnDefinition Width="12" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <ui:NumberBox Header="Taille du groupe"
+                                <ui:NumberBox Header="{Binding Source={StaticResource Loc}, Path=[Field_GroupSize]}"
                                               Value="{Binding Profile.GroupSize, Mode=TwoWay}"
                                               Minimum="1"
                                               SpinButtonPlacementMode="Inline"
                                               Grid.Column="0" />
                             </Grid>
                             <ui:SimpleStackPanel Spacing="6">
-                                <TextBlock Text="Nombre de mots" />
+                                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Field_WordCount]}" />
                                 <TextBox Text="{Binding Profile.WordCount, Mode=TwoWay}"
                                          Style="{StaticResource ModernReadOnlyTextBoxStyle}" />
                             </ui:SimpleStackPanel>
@@ -281,7 +281,7 @@
                             </Style>
                         </Border.Style>
                         <ui:SimpleStackPanel Spacing="12">
-                            <ui:NumberBox Header="Nombre de mots"
+                            <ui:NumberBox Header="{Binding Source={StaticResource Loc}, Path=[Field_WordCount]}"
                                           Value="{Binding Profile.WordCount, Mode=TwoWay}"
                                           Minimum="1"
                                           SpinButtonPlacementMode="Inline" />
@@ -293,7 +293,7 @@
                                     <ColumnDefinition Width="12" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <ui:NumberBox Header="Taille du groupe"
+                                <ui:NumberBox Header="{Binding Source={StaticResource Loc}, Path=[Field_GroupSize]}"
                                               Value="{Binding Profile.GroupSize, Mode=TwoWay}"
                                               Minimum="1"
                                               SpinButtonPlacementMode="Inline"
@@ -308,19 +308,19 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <ui:SimpleStackPanel Spacing="6">
-                                    <TextBlock Text="Heures" />
+                                    <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Hours]}" />
                                     <TextBox Text="{Binding Profile.TaskDuration, Converter={StaticResource MillisecondsToHoursConverter}}"
                                              Style="{StaticResource ModernReadOnlyTextBoxStyle}" />
                                 </ui:SimpleStackPanel>
                                 <ui:SimpleStackPanel Spacing="6"
                                                      Grid.Column="2">
-                                    <TextBlock Text="Minutes" />
+                                    <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Minutes]}" />
                                     <TextBox Text="{Binding Profile.TaskDuration, Converter={StaticResource MillisecondsToMinutesConverter}}"
                                              Style="{StaticResource ModernReadOnlyTextBoxStyle}" />
                                 </ui:SimpleStackPanel>
                                 <ui:SimpleStackPanel Spacing="6"
                                                      Grid.Column="4">
-                                    <TextBlock Text="Secondes" />
+                                    <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Seconds]}" />
                                     <TextBox Text="{Binding Profile.TaskDuration, Converter={StaticResource MillisecondsToSecondsConverter}}"
                                              Style="{StaticResource ModernReadOnlyTextBoxStyle}" />
                                 </ui:SimpleStackPanel>
@@ -338,10 +338,10 @@
                                  Spacing="16"
                                  VerticalAlignment="Center"
                                  HorizontalAlignment="Center">
-                <Button Content="Annuler"
+                <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Cancel]}"
                         Style="{StaticResource OpaqueButtonStyle}"
                         Command="{Binding CancelCommand}" />
-                <Button Content="Enregistrer"
+                <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Save]}"
                         Style="{StaticResource AccentButtonStyle}"
                         Command="{Binding SaveCommand}" />
             </ui:SimpleStackPanel>

--- a/StroopApp/Views/Configuration/Profile/ProfileManagementView.xaml
+++ b/StroopApp/Views/Configuration/Profile/ProfileManagementView.xaml
@@ -24,9 +24,9 @@
                 BorderThickness="0.5"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="10">
-                <TextBlock Text="Choix du profil de l'expérience"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileManagement_Title]}"
                            Style="{DynamicResource TitleTextBlockStyle}" />
-                <TextBlock Text="Sélectionnez le profil à utiliser pour configurer votre expérience."
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileManagement_Description]}"
                            Style="{DynamicResource CaptionTextBlockStyle}" />
                 <ui:SimpleStackPanel Orientation="Horizontal"
                                      HorizontalAlignment="Left"
@@ -37,13 +37,13 @@
                               SelectedItem="{Binding CurrentProfile}"
                               DisplayMemberPath="ProfileName"
                               Background="{DynamicResource SystemControlBackgroundAltHighBrush}" />
-                    <Button Content="Créer"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Create]}"
                             Command="{Binding CreateProfileCommand}"
                             Style="{DynamicResource DefaultButtonStyle}" />
-                    <Button Content="Modifier"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Edit]}"
                             Command="{Binding ModifyProfileCommand}"
                             Style="{DynamicResource DefaultButtonStyle}" />
-                    <Button Content="Supprimer"
+                    <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Delete]}"
                             Command="{Binding DeleteProfileCommand}"
                             Style="{DynamicResource DefaultButtonStyle}" />
                 </ui:SimpleStackPanel>
@@ -56,7 +56,7 @@
                 BorderThickness="0.5"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="10">
-                <TextBlock Text="Détails du profil sélectionné"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ProfileManagement_DetailsTitle]}"
                            Style="{DynamicResource TitleTextBlockStyle}" />
                 <Grid Margin="0">
                     <Grid.ColumnDefinitions>
@@ -77,7 +77,7 @@
                                                  Exemple : 25 % = 75 % d’incongruents, 25 % de congruents."
                                                  ToolTipService.Placement="Top"
                                                  ToolTipService.InitialShowDelay="100">
-                                <TextBlock Text="Congruence (%)" />
+                                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Congruence]}" />
                                 <TextBlock Text=""
                                            FontFamily="Segoe MDL2 Assets"
                                            FontSize="14"
@@ -97,7 +97,7 @@
                                                  Exemple : 100 % = alternance à chaque essai, 0 % = toujours la même forme."
                                                  ToolTipService.Placement="Top"
                                                  ToolTipService.InitialShowDelay="100">
-                                <TextBlock Text="Switch (%)" />
+                                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Header_Switch]}" />
                                 <TextBlock Text=""
                                            FontFamily="Segoe MDL2 Assets"
                                            FontSize="14"
@@ -113,25 +113,25 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0"
-                                 ui:ControlHelper.Header="Heures"
+                                 ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Hours]}"
                                  Text="{Binding CurrentProfile.TaskDuration, Converter={StaticResource MillisecondsToHoursConverter}}"
                                  Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                         <TextBox Grid.Column="1"
                                  Text="{Binding CurrentProfile.TaskDuration, Converter={StaticResource MillisecondsToMinutesConverter}}"
-                                 ui:ControlHelper.Header="Minutes"
+                                 ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Minutes]}"
                                  Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                         <TextBox Grid.Column="2"
                                  Text="{Binding CurrentProfile.TaskDuration, Converter={StaticResource MillisecondsToSecondsConverter}}"
-                                 ui:ControlHelper.Header="Secondes"
+                                 ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Seconds]}"
                                  Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                     </Grid>
                     <TextBox Grid.Column="3"
                              Text="{Binding CurrentProfile.MaxReactionTime}"
-                             ui:ControlHelper.Header="Temps de réaction max (ms)"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_MaxReactionTime]}"
                              Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                     <TextBox Grid.Column="4"
                              Text="{Binding CurrentProfile.WordDuration}"
-                             ui:ControlHelper.Header="Durée par mot (ms)"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_WordDuration]}"
                              Style="{DynamicResource ModernReadOnlyTextBoxStyle}" />
                 </Grid>
             </ui:SimpleStackPanel>

--- a/StroopApp/Views/Configuration/Profile/SwitchSettingsView.xaml
+++ b/StroopApp/Views/Configuration/Profile/SwitchSettingsView.xaml
@@ -88,7 +88,7 @@
                     <ColumnDefinition Width="16" />
                     <ColumnDefinition Width="0.3*" />
                 </Grid.ColumnDefinitions>
-                <Slider ui:ControlHelper.Header="Pourcentage de switch"
+                <Slider ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Switch] }"
                         Minimum="0"
                         Maximum="100"
                         LargeChange="5"

--- a/StroopApp/Views/Experiment/Experimenter/EndExperimentPage.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/EndExperimentPage.xaml
@@ -20,7 +20,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0"
-                       Text="Bloc terminé"
+                       Text="{Binding Source={StaticResource Loc}, Path=[EndExperiment_BlockFinished]}"
                        Style="{DynamicResource HeaderTextBlockStyle}"
                        VerticalAlignment="Center" />
 
@@ -49,7 +49,7 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0"
-                           Text="Résumé des blocs"
+                           Text="{Binding Source={StaticResource Loc}, Path=[EndExperiment_BlockSummary]}"
                            Style="{DynamicResource TitleTextBlockStyle}"
                            Margin="0,0,0,12" />
                 <Border Grid.Row="3"
@@ -71,15 +71,15 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Bloc"
+                            <DataGridTextColumn Header="{Binding Source={StaticResource Loc}, Path=[Header_Block]}"
                                                 Binding="{Binding BlockNumber, StringFormat=Bloc {0}}" />
-                            <DataGridTextColumn Header="Essais"
+                            <DataGridTextColumn Header="{Binding Source={StaticResource Loc}, Path=[Header_Trials]}"
                                                 Binding="{Binding TotalTrials}" />
-                            <DataGridTextColumn Header="Précision"
+                            <DataGridTextColumn Header="{Binding Source={StaticResource Loc}, Path=[Header_Accuracy]}"
                                                 Binding="{Binding Accuracy, StringFormat={}{0}%}" />
-                            <DataGridTextColumn Header="Temps moyen de réponse"
+                            <DataGridTextColumn Header="{Binding Source={StaticResource Loc}, Path=[Header_MeanReactionTime]}"
                                                 Binding="{Binding ResponseTimeMean, StringFormat={}{0} ms}" />
-                            <DataGridTextColumn Header="Type Stroop"
+                            <DataGridTextColumn Header="{Binding Source={StaticResource Loc}, Path=[Header_StroopType]}"
                                                 Binding="{Binding StroopType}" />
                         </DataGrid.Columns>
                     </DataGrid>
@@ -98,13 +98,13 @@
                              Spacing="16"
                              Grid.Row="6"
                              HorizontalAlignment="Center">
-            <Button Content="Relancer"
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Continue]}"
                     Command="{Binding ContinueCommand}"
                     Style="{DynamicResource AccentButtonStyle}"
                     IsDefault="True" />
-            <Button Content="Nouvelle expérience"
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_NewExperiment]}"
                     Command="{Binding RestartCommand}"/>
-            <Button Content="Quitter l'application"
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Quit]}"
                     Command="{Binding QuitCommand}"
                     IsCancel="True" />
         </ui:SimpleStackPanel>

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml
@@ -10,7 +10,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
-                   Text="Tableau de bord de l'expérience en cours"
+                   Text="{Binding Source={StaticResource Loc}, Path=[Dashboard_Title]}"
                    Style="{DynamicResource HeaderTextBlockStyle}"
                    HorizontalAlignment="Left"
                    Margin="0,0,0,12" />

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentProgressView.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentProgressView.xaml
@@ -31,7 +31,7 @@
                                  HorizontalAlignment="Stretch"
                                  VerticalAlignment="Top"
                                  Spacing="16">
-                <TextBlock Text="Avancement"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Progress_Title]}"
                            Style="{DynamicResource TitleTextBlockStyle}"
                            HorizontalAlignment="Left" />
                 <TextBlock Grid.Column="0"
@@ -57,7 +57,7 @@
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="10">
                 <!-- Section Détails du participant -->
-                <TextBlock Text="Détails du participant"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ParticipantDetails_Title]}"
                            Style="{DynamicResource TitleTextBlockStyle}" />
                 <Grid Margin="0">
                     <Grid.ColumnDefinitions>
@@ -68,7 +68,7 @@
                     <TextBox Grid.Column="0"
                              Text="{Binding settings.Participant.Id}"
                              HorizontalAlignment="Stretch"
-                             ui:ControlHelper.Header="Participant ID"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_ParticipantId]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              IsHitTestVisible="False"
@@ -78,7 +78,7 @@
                     <TextBox Grid.Column="1"
                              Text="{Binding settings.Block}"
                              HorizontalAlignment="Stretch"
-                             ui:ControlHelper.Header="Bloc"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Block]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              IsHitTestVisible="False"
@@ -95,7 +95,7 @@
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
             <ui:SimpleStackPanel Spacing="10">
                 <!-- Section Détails de l'expérience -->
-                <TextBlock Text="Détails de l'expérience"
+                <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[ExperimentDetails_Title]}"
                            Style="{DynamicResource TitleTextBlockStyle}" />
                 <Grid Margin="0">
                     <Grid.ColumnDefinitions>
@@ -117,7 +117,7 @@
                     <TextBox Grid.Column="0"
                              Text="{Binding settings.CurrentProfile.CongruencePourcentage}"
                              HorizontalAlignment="Stretch"
-                             ui:ControlHelper.Header="Pourcentage de congruence"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Congruence]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              IsHitTestVisible="False"
@@ -126,7 +126,7 @@
                     <TextBox Grid.Column="1"
                              Text="{Binding settings.CurrentProfile.SwitchPourcentage}"
                              HorizontalAlignment="Stretch"
-                             ui:ControlHelper.Header="Pourcentage de switch"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Switch]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              IsHitTestVisible="False"
@@ -139,7 +139,7 @@
                              Text="{Binding settings.CurrentProfile.Hours}"
                              IsReadOnly="True"
                              HorizontalAlignment="Center"
-                             ui:ControlHelper.Header="Heures"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Hours]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              Padding="4"
@@ -150,7 +150,7 @@
                              Text="{Binding settings.CurrentProfile.Minutes}"
                              IsReadOnly="True"
                              HorizontalAlignment="Center"
-                             ui:ControlHelper.Header="Minutes"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Minutes]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              Padding="4"
@@ -161,7 +161,7 @@
                              Text="{Binding settings.CurrentProfile.Seconds}"
                              IsReadOnly="True"
                              HorizontalAlignment="Center"
-                             ui:ControlHelper.Header="Secondes"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_Seconds]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              Padding="4"
@@ -172,7 +172,7 @@
                              Text="{Binding settings.CurrentProfile.MaxReactionTime}"
                              IsReadOnly="True"
                              HorizontalAlignment="Stretch"
-                             ui:ControlHelper.Header="Temps de réaction max (ms)"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_MaxReactionTime]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              Padding="4"
@@ -183,7 +183,7 @@
                              Text="{Binding settings.CurrentProfile.WordDuration}"
                              IsReadOnly="True"
                              HorizontalAlignment="Stretch"
-                             ui:ControlHelper.Header="Durée par mot (ms)"
+                             ui:ControlHelper.Header="{Binding Source={StaticResource Loc}, Path=[Header_WordDuration]}"
                              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                              BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                              Padding="4"

--- a/StroopApp/Views/Experiment/Experimenter/Graphs/GraphsView.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/Graphs/GraphsView.xaml
@@ -27,7 +27,7 @@
                 <RowDefinition Height="8" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <TextBlock Text="Suivi de l'expérience"
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[GraphsView_Title]}"
                        Style="{DynamicResource TitleTextBlockStyle}"
                        Grid.Row="0" />
         </Grid>

--- a/StroopApp/Views/Experiment/Participant/EndInstructionsPage.xaml
+++ b/StroopApp/Views/Experiment/Participant/EndInstructionsPage.xaml
@@ -8,7 +8,7 @@
       mc:Ignorable="d">
     <Grid Background="Black"
           Margin="40">
-        <TextBlock Text="Félicitations ! Vous avez terminé l'expérience."
+        <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[EndInstructions_Message]}"
                    HorizontalAlignment="Center"
                    VerticalAlignment="Center"
                    TextWrapping="Wrap"


### PR DESCRIPTION
## Summary
- localize configuration and experiment views
- update resource files with new keys for headers and toggle text

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851aa0aa38c832fa738d661fab355d0