### PR TITLE
Feature/interrupt-experiment

### DIFF
--- a/StroopApp.XUnitTests/TestDummies/DummyTrialGenerationService.cs
+++ b/StroopApp.XUnitTests/TestDummies/DummyTrialGenerationService.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+
+using StroopApp.Models;
+using StroopApp.Services.Trial;
+
+namespace StroopApp.XUnitTests.TestDummies
+{
+	public class DummyTrialGenerationService : ITrialGenerationService
+	{
+		public bool GenerateTrialsCalled { get; private set; }
+		public bool GenerateAmorceSequenceCalled { get; private set; }
+		public int LastTrialCount { get; private set; }
+
+		public List<StroopTrial> GenerateTrials(ExperimentSettings settings)
+		{
+			GenerateTrialsCalled = true;
+
+			if (settings?.CurrentProfile == null)
+				return new List<StroopTrial>();
+
+			var trials = new List<StroopTrial>();
+			int trialCount = settings.CurrentProfile.WordCount;
+			LastTrialCount = trialCount;
+
+			// Générer des trials de test simples
+			for (int i = 0; i < trialCount; i++)
+			{
+				trials.Add(new StroopTrial
+				{
+					TrialNumber = i + 1,
+					Block = settings.Block,
+					ParticipantId = settings.Participant?.Id ?? "TestParticipant",
+					IsCongruent = i % 2 == 0, // Alternance congruent/incongruent
+					ExpectedAnswer = "TestAnswer",
+					Stimulus = new Word("Red", "Red", "RED")
+				});
+			}
+
+			return trials;
+		}
+
+		public List<AmorceType> GenerateAmorceSequence(int count, int switchPercentage)
+		{
+			GenerateAmorceSequenceCalled = true;
+
+			var sequence = new List<AmorceType>();
+			for (int i = 0; i < count; i++)
+			{
+				sequence.Add(i % 2 == 0 ? AmorceType.Square : AmorceType.Round);
+			}
+
+			return sequence;
+		}
+	}
+}

--- a/StroopApp.XUnitTests/ViewModels/Configuration/ConfigurationPageViewModelTests.cs
+++ b/StroopApp.XUnitTests/ViewModels/Configuration/ConfigurationPageViewModelTests.cs
@@ -15,43 +15,48 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 		public void LaunchExperiment_WithProfileAndParticipant_NavigatesAndOpensWindow()
 		{
 			// Arrange
-			ExperimentSettings? settings = new ExperimentSettings();
-			// Services
-			DummyProfileService? dummyProfileService = new DummyProfileService();
-			DummyParticipantService? dummyParticipantService = new DummyParticipantService();
-			DummyKeyMappingService? dummyKeyMappingService = new DummyKeyMappingService();
-			DummyExportationService? dummyExportationService = new DummyExportationService();
-			DummyWindowManager? dummyWindowManager = new DummyWindowManager();
-			DummyNavigationService? dummyNavigationService = new DummyNavigationService();
+			var settings = new ExperimentSettings();
+			var dummyProfileService = new DummyProfileService();
+			var dummyParticipantService = new DummyParticipantService();
+			var dummyKeyMappingService = new DummyKeyMappingService();
+			var dummyWindowManager = new DummyWindowManager();
+			var dummyNavigationService = new DummyNavigationService();
+			var dummyTrialGenerationService = new DummyTrialGenerationService();
 
-			//ViewModels
-			ProfileManagementViewModel? profileViewModel = new ProfileManagementViewModel(profileService: dummyProfileService);
-			ParticipantManagementViewModel? participantViewModel = new ParticipantManagementViewModel(participantService: dummyParticipantService, isParticipantSelectionEnabled: false); // We assume it's the first experiment launched.
-			KeyMappingViewModel? keyMappingViewModel = new KeyMappingViewModel(keyMappingService: dummyKeyMappingService);
+			var profileViewModel = new ProfileManagementViewModel(dummyProfileService);
+			var participantViewModel = new ParticipantManagementViewModel(dummyParticipantService, false);
+			var keyMappingViewModel = new KeyMappingViewModel(dummyKeyMappingService);
 
 			var viewModel = new ConfigurationPageViewModel(
-			settings,
-			profileViewModel,
-			participantViewModel,
-			keyMappingViewModel,
-			dummyNavigationService,
-			dummyWindowManager
-			);
-			// Current Participant Selected
-			ExperimentProfile? dummyProfile = new ExperimentProfile { ProfileName = "TestProfile" };
+				settings,
+				profileViewModel,
+				participantViewModel,
+				keyMappingViewModel,
+				dummyNavigationService,
+				dummyWindowManager,
+				dummyTrialGenerationService);
+
+			var dummyProfile = new ExperimentProfile
+			{
+				ProfileName = "TestProfile",
+				WordCount = 10
+			};
 			profileViewModel.CurrentProfile = dummyProfile;
 
-			Participant? dummyParticipant = new Participant { Id = "15j16" };
+			var dummyParticipant = new Participant { Id = "15j16" };
 			participantViewModel.SelectedParticipant = dummyParticipant;
 
 			// Act
 			viewModel.LaunchExperimentCommand.Execute(null);
 
-			// Arrange
+			// Assert
 			Assert.True(dummyNavigationService.Navigated);
 			Assert.True(dummyWindowManager.ShowCalled);
+			Assert.True(dummyTrialGenerationService.GenerateTrialsCalled);
 			Assert.Equal(dummyProfile, settings.CurrentProfile);
 			Assert.Equal(dummyParticipant, settings.Participant);
+			Assert.NotNull(settings.ExperimentContext.CurrentBlock);
+			Assert.Equal(10, dummyTrialGenerationService.LastTrialCount);
 		}
 
 		[Fact]
@@ -64,9 +69,10 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 			var dummyKeyMappingService = new DummyKeyMappingService();
 			var dummyWindowManager = new DummyWindowManager();
 			var dummyNavigationService = new DummyNavigationService();
+			var dummyTrialGenerationService = new DummyTrialGenerationService();
 
 			var profileViewModel = new ProfileManagementViewModel(dummyProfileService);
-			// No CurrentProfile !
+			// No CurrentProfile set intentionally
 
 			var participantViewModel = new ParticipantManagementViewModel(dummyParticipantService, false);
 			participantViewModel.SelectedParticipant = new Participant { Id = "15h61" };
@@ -79,8 +85,8 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 				participantViewModel,
 				keyMappingViewModel,
 				dummyNavigationService,
-				dummyWindowManager
-			);
+				dummyWindowManager,
+				dummyTrialGenerationService);
 
 			// Act
 			viewModel.LaunchExperimentCommand.Execute(null);
@@ -90,7 +96,9 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 			Assert.Equal(Strings.Error_SelectProfile, viewModel.LastErrorMessage);
 			Assert.False(dummyNavigationService.Navigated);
 			Assert.False(dummyWindowManager.ShowCalled);
+			Assert.False(dummyTrialGenerationService.GenerateTrialsCalled);
 		}
+
 		[Fact]
 		public void LaunchExperiment_WithoutParticipant_ShowsErrorDialog()
 		{
@@ -101,13 +109,14 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 			var dummyKeyMappingService = new DummyKeyMappingService();
 			var dummyWindowManager = new DummyWindowManager();
 			var dummyNavigationService = new DummyNavigationService();
+			var dummyTrialGenerationService = new DummyTrialGenerationService();
 
 			var profileViewModel = new ProfileManagementViewModel(dummyProfileService);
-			ExperimentProfile? dummyProfile = new ExperimentProfile { ProfileName = "TestProfile" };
+			var dummyProfile = new ExperimentProfile { ProfileName = "TestProfile" };
 			profileViewModel.CurrentProfile = dummyProfile;
 
 			var participantViewModel = new ParticipantManagementViewModel(dummyParticipantService, false);
-			// No SelectedParticipant !
+			// No SelectedParticipant set intentionally
 
 			var keyMappingViewModel = new KeyMappingViewModel(dummyKeyMappingService);
 
@@ -117,8 +126,8 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 				participantViewModel,
 				keyMappingViewModel,
 				dummyNavigationService,
-				dummyWindowManager
-			);
+				dummyWindowManager,
+				dummyTrialGenerationService);
 
 			// Act
 			viewModel.LaunchExperimentCommand.Execute(null);
@@ -128,6 +137,47 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 			Assert.Equal(Strings.Error_SelectParticipant, viewModel.LastErrorMessage);
 			Assert.False(dummyNavigationService.Navigated);
 			Assert.False(dummyWindowManager.ShowCalled);
+			Assert.False(dummyTrialGenerationService.GenerateTrialsCalled);
+		}
+
+		[Fact]
+		public void LaunchExperiment_WithValidSettings_GeneratesTrialsCorrectly()
+		{
+			// Arrange
+			var settings = new ExperimentSettings();
+			var dummyTrialGenerationService = new DummyTrialGenerationService();
+			var dummyWindowManager = new DummyWindowManager();
+			var dummyNavigationService = new DummyNavigationService();
+
+			var profileViewModel = new ProfileManagementViewModel(new DummyProfileService());
+			var participantViewModel = new ParticipantManagementViewModel(new DummyParticipantService(), false);
+			var keyMappingViewModel = new KeyMappingViewModel(new DummyKeyMappingService());
+
+			var viewModel = new ConfigurationPageViewModel(
+				settings,
+				profileViewModel,
+				participantViewModel,
+				keyMappingViewModel,
+				dummyNavigationService,
+				dummyWindowManager,
+				dummyTrialGenerationService);
+
+			var profile = new ExperimentProfile
+			{
+				ProfileName = "TestProfile",
+				WordCount = 20
+			};
+			profileViewModel.CurrentProfile = profile;
+			participantViewModel.SelectedParticipant = new Participant { Id = "TestParticipant" };
+
+			// Act
+			viewModel.LaunchExperimentCommand.Execute(null);
+
+			// Assert
+			Assert.True(dummyTrialGenerationService.GenerateTrialsCalled);
+			Assert.Equal(20, dummyTrialGenerationService.LastTrialCount);
+			Assert.NotNull(settings.ExperimentContext.CurrentBlock);
+			Assert.Equal(20, settings.ExperimentContext.CurrentBlock.TrialRecords.Count);
 		}
 	}
 }

--- a/StroopApp.XUnitTests/ViewModels/Configuration/TestableConfigurationPageViewModel.cs
+++ b/StroopApp.XUnitTests/ViewModels/Configuration/TestableConfigurationPageViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using StroopApp.Models;
 using StroopApp.Services.Navigation;
+using StroopApp.Services.Trial;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.Configuration;
 using StroopApp.ViewModels.Configuration.Participant;
@@ -23,8 +24,10 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 			ParticipantManagementViewModel participantViewModel,
 			KeyMappingViewModel keyMappingViewModel,
 			INavigationService experimenterNavigationService,
-			IWindowManager windowManager
-		) : base(settings, profileViewModel, participantViewModel, keyMappingViewModel, experimenterNavigationService, windowManager)
+			IWindowManager windowManager,
+			ITrialGenerationService trialGenerationService
+
+		) : base(settings, profileViewModel, participantViewModel, keyMappingViewModel, experimenterNavigationService, windowManager, trialGenerationService)
 		{ }
 
 		protected override void ShowErrorDialog(string message)

--- a/StroopApp/Core/ViewModelBase.cs
+++ b/StroopApp/Core/ViewModelBase.cs
@@ -28,17 +28,16 @@ namespace StroopApp.Core
 
 			await dialog.ShowAsync();
 		}
-		public async Task<bool> ShowConfirmationDialog(string message)
+		public async Task<bool> ShowConfirmationDialog(string title, string message)
 		{
 			var dlg = new ContentDialog
 			{
-				Title = Strings.Title_DeleteConfirmation,
+				Title = title,
 				Content = message,
 				PrimaryButtonText = Strings.Button_Confirm,
 				CloseButtonText = Strings.Button_Cancel
 			};
 			return await dlg.ShowAsync() == ContentDialogResult.Primary;
 		}
-
 	}
 }

--- a/StroopApp/Models/Block.cs
+++ b/StroopApp/Models/Block.cs
@@ -111,11 +111,10 @@ public class Block : ModelBase
 
 	public void CalculateValues()
 	{
-		bool CountIsZero = TrialRecords.Count == 0;
-		TrialsPerBlock = CountIsZero ? TrialRecords.Count : _settings.CurrentProfile.WordCount;
-		Accuracy = TrialRecords.Any()
-					  ? TrialRecords.Count(t => t.IsValidResponse == true) / (double)TrialsPerBlock * 100
-					  : 0;
+		TrialsPerBlock = TrialRecords.Count;
+		Accuracy = TrialsPerBlock > 0
+		? TrialRecords.Count(t => t.IsValidResponse == true) / (double)TrialsPerBlock * 100
+		: 0;
 		ResponseTimeMean = TrialRecords
 									.Where(trial => trial.ReactionTime.HasValue && trial.Block == BlockNumber)
 									.Select(trial => trial.ReactionTime)

--- a/StroopApp/Models/Block.cs
+++ b/StroopApp/Models/Block.cs
@@ -111,7 +111,8 @@ public class Block : ModelBase
 
 	public void CalculateValues()
 	{
-		TrialsPerBlock = TrialRecords.Count;
+		bool CountIsZero = TrialRecords.Count == 0;
+		TrialsPerBlock = CountIsZero ? TrialRecords.Count : _settings.CurrentProfile.WordCount;
 		Accuracy = TrialRecords.Any()
 					  ? TrialRecords.Count(t => t.IsValidResponse == true) / (double)TrialsPerBlock * 100
 					  : 0;

--- a/StroopApp/Models/SharedExperimentData.cs
+++ b/StroopApp/Models/SharedExperimentData.cs
@@ -109,6 +109,18 @@ namespace StroopApp.Models
 				}
 			}
 		}
+
+		private bool _isTaskStopped = false;
+		public bool IsTaskStopped
+		{
+			get => _isTaskStopped;
+			set
+			{
+				_isTaskStopped = value;
+				OnPropertyChanged();
+			}
+		}
+
 		private bool _isParticipantSelectionEnabled = true;
 		public bool IsParticipantSelectionEnabled
 		{
@@ -237,6 +249,7 @@ namespace StroopApp.Models
 			BlockSeries.Clear();
 			Sections.Clear();
 			ReactionPoints.Clear();
+			IsTaskStopped = false;
 			_colorIndex = 0;
 			currentBlockStart = 1;
 			currentBlockEnd = 0;

--- a/StroopApp/Resources/Strings.Designer.cs
+++ b/StroopApp/Resources/Strings.Designer.cs
@@ -1330,6 +1330,15 @@ namespace StroopApp.Resources {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Starting a new experiment will discard the current data. Do you want to continue ?.
+        /// </summary>
+        public static string Message_ConfirmNewExperiment {
+            get {
+                return ResourceManager.GetString("Message_ConfirmNewExperiment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Do you really want to delete this participant ? Their data will be archived..
         /// </summary>
         public static string Message_DeleteParticipantConfirmation {
@@ -1489,6 +1498,15 @@ namespace StroopApp.Resources {
         public static string Title_ConfigPage {
             get {
                 return ResourceManager.GetString("Title_ConfigPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Confirm new experiment.
+        /// </summary>
+        public static string Title_ConfirmNewExperiment {
+            get {
+                return ResourceManager.GetString("Title_ConfirmNewExperiment", resourceCulture);
             }
         }
         

--- a/StroopApp/Resources/Strings.Designer.cs
+++ b/StroopApp/Resources/Strings.Designer.cs
@@ -304,6 +304,15 @@ namespace StroopApp.Resources {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Interrupt the task.
+        /// </summary>
+        public static string Button_StopTask {
+            get {
+                return ResourceManager.GetString("Button_StopTask", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à These words will always be written with ink of a different color than the meaning of the word..
         /// </summary>
         public static string Case1_P1_Congruence {
@@ -1376,6 +1385,15 @@ namespace StroopApp.Resources {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Are you sure you want to stop the current task? Partial data can be exported..
+        /// </summary>
+        public static string Message_StopTask {
+            get {
+                return ResourceManager.GetString("Message_StopTask", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à A fixation cross will appear, followed by a color word..
         /// </summary>
         public static string Page1_Display_NoCue {
@@ -1471,6 +1489,24 @@ namespace StroopApp.Resources {
         public static string Title_ConfigPage {
             get {
                 return ResourceManager.GetString("Title_ConfigPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Confirm shutdown.
+        /// </summary>
+        public static string Title_ConfirmShutDown {
+            get {
+                return ResourceManager.GetString("Title_ConfirmShutDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Confirm task interruption.
+        /// </summary>
+        public static string Title_ConfirmStopTask {
+            get {
+                return ResourceManager.GetString("Title_ConfirmStopTask", resourceCulture);
             }
         }
         
@@ -1687,6 +1723,15 @@ namespace StroopApp.Resources {
         public static string Tooltip_CueSquareResponse {
             get {
                 return ResourceManager.GetString("Tooltip_CueSquareResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Interrupt the running task and keep the partial data..
+        /// </summary>
+        public static string Tooltip_StopTask {
+            get {
+                return ResourceManager.GetString("Tooltip_StopTask", resourceCulture);
             }
         }
         

--- a/StroopApp/Resources/Strings.fr.resx
+++ b/StroopApp/Resources/Strings.fr.resx
@@ -691,4 +691,10 @@
   <data name="Title_ConfirmStopTask" xml:space="preserve">
     <value>Confirmer l’interruption de la tâche</value>
   </data>
+  <data name="Title_ConfirmNewExperiment" xml:space="preserve">
+    <value>Confirmer la nouvelle expérience</value>
+  </data>
+  <data name="Message_ConfirmNewExperiment" xml:space="preserve">
+    <value>Démarrer une nouvelle expérience entraînera la perte des données actuelles. Voulez-vous continuer ?</value>
+  </data>
 </root>

--- a/StroopApp/Resources/Strings.fr.resx
+++ b/StroopApp/Resources/Strings.fr.resx
@@ -499,6 +499,9 @@
   <data name="Button_AdvancedSettings" xml:space="preserve">
     <value>Paramètres avancés</value>
   </data>
+  <data name="Button_Quit_Without_Export" xml:space="preserve">
+    <value>Quitter l'application sans exporter</value>
+  </data>
   <data name="Label_StopBits" xml:space="preserve">
     <value>Stop bits</value>
   </data>
@@ -513,9 +516,6 @@
   </data>
   <data name="Check_AddPrime" xml:space="preserve">
     <value>Ajouter indice visuel</value>
-  </data>
-  <data name="Button_Quit_Without_Export" xml:space="preserve">
-    <value>Quitter l'application sans exporter</value>
   </data>
   <data name="Error_FillIdField" xml:space="preserve">
     <value>Remplissez au moins le champ ID</value>
@@ -675,5 +675,20 @@
   </data>
   <data name="Case6_P2_InstructionsWithCue" xml:space="preserve">
     <value>Appuyez sur la touche correspondant aux instructions, le plus rapidement possible, en faisant le moins d'erreurs.</value>
+  </data>
+  <data name="Button_StopTask" xml:space="preserve">
+    <value>Interrompre la tâche</value>
+  </data>
+  <data name="Tooltip_StopTask" xml:space="preserve">
+    <value>Arrêter l'expérience en cours et conserver les données partielles.</value>
+  </data>
+  <data name="Message_StopTask" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir interrompre la tâche en cours ? Les données partielles pourront être exportées.</value>
+  </data>
+  <data name="Title_ConfirmShutDown" xml:space="preserve">
+    <value>Confirmer la fermeture</value>
+  </data>
+  <data name="Title_ConfirmStopTask" xml:space="preserve">
+    <value>Confirmer l’interruption de la tâche</value>
   </data>
 </root>

--- a/StroopApp/Resources/Strings.resx
+++ b/StroopApp/Resources/Strings.resx
@@ -694,4 +694,10 @@
   <data name="Title_ConfirmStopTask" xml:space="preserve">
     <value>Confirm task interruption</value>
   </data>
+  <data name="Title_ConfirmNewExperiment" xml:space="preserve">
+    <value>Confirm new experiment</value>
+  </data>
+  <data name="Message_ConfirmNewExperiment" xml:space="preserve">
+    <value>Starting a new experiment will discard the current data. Do you want to continue ?</value>
+  </data>
 </root>

--- a/StroopApp/Resources/Strings.resx
+++ b/StroopApp/Resources/Strings.resx
@@ -679,4 +679,19 @@
   <data name="Case6_P2_InstructionsWithCue" xml:space="preserve">
     <value>Press the key corresponding to the instruction as quickly as possible, making the fewest mistakes.</value>
   </data>
+  <data name="Button_StopTask" xml:space="preserve">
+    <value>Interrupt the task</value>
+  </data>
+  <data name="Tooltip_StopTask" xml:space="preserve">
+    <value>Interrupt the running task and keep the partial data.</value>
+  </data>
+  <data name="Message_StopTask" xml:space="preserve">
+    <value>Are you sure you want to stop the current task? Partial data can be exported.</value>
+  </data>
+  <data name="Title_ConfirmShutDown" xml:space="preserve">
+    <value>Confirm shutdown</value>
+  </data>
+  <data name="Title_ConfirmStopTask" xml:space="preserve">
+    <value>Confirm task interruption</value>
+  </data>
 </root>

--- a/StroopApp/Services/Trial/ITrialGenerationService.cs
+++ b/StroopApp/Services/Trial/ITrialGenerationService.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+using StroopApp.Models;
+
+namespace StroopApp.Services.Trial
+{
+	public interface ITrialGenerationService
+	{
+		/// <summary>
+		/// Génère une liste de trials basée sur les paramètres d'expérience
+		/// </summary>
+		/// <param name="settings">Paramètres de l'expérience</param>
+		/// <returns>Liste des trials générés</returns>
+		List<StroopTrial> GenerateTrials(ExperimentSettings settings);
+
+		/// <summary>
+		/// Génère une séquence d'amorces (optionnel)
+		/// </summary>
+		/// <param name="count">Nombre d'amorces à générer</param>
+		/// <param name="switchPercentage">Pourcentage de changement d'amorce</param>
+		/// <returns>Séquence d'amorces</returns>
+		List<AmorceType> GenerateAmorceSequence(int count, int switchPercentage);
+	}
+}

--- a/StroopApp/Services/Trial/TrialGenerationService.cs
+++ b/StroopApp/Services/Trial/TrialGenerationService.cs
@@ -1,0 +1,123 @@
+﻿using System.Globalization;
+
+using StroopApp.Core;
+using StroopApp.Models;
+
+namespace StroopApp.Services.Trial
+{
+	public class TrialGenerationService : ITrialGenerationService
+	{
+		private readonly Random _random = new Random();
+
+		public List<StroopTrial> GenerateTrials(ExperimentSettings settings)
+		{
+			if (settings?.CurrentProfile == null)
+				throw new ArgumentException("Settings et CurrentProfile ne peuvent pas être null", nameof(settings));
+
+			var trials = new List<StroopTrial>();
+			var wordColors = new[] { "Blue", "Red", "Green", "Yellow" };
+
+			// ✅ Configuration de la culture pour les mots localisés
+			var culture = new CultureInfo(settings.CurrentProfile.TaskLanguage ?? "en");
+			Thread.CurrentThread.CurrentCulture = culture;
+			Thread.CurrentThread.CurrentUICulture = culture;
+
+			var loc = new LocalizedStrings();
+			var wordTexts = new[]
+			{
+				loc["Word_BLUE"],
+				loc["Word_RED"],
+				loc["Word_GREEN"],
+				loc["Word_YELLOW"]
+			};
+
+			int total = settings.CurrentProfile.WordCount;
+			int congruentCount = total * settings.CurrentProfile.CongruencePercent / 100;
+			int incongruentCount = total - congruentCount;
+
+			// ✅ Génération des flags de congruence de manière aléatoire
+			var congruenceFlags = new List<bool>();
+			congruenceFlags.AddRange(Enumerable.Repeat(true, congruentCount));
+			congruenceFlags.AddRange(Enumerable.Repeat(false, incongruentCount));
+			congruenceFlags = congruenceFlags.OrderBy(_ => _random.Next()).ToList();
+
+			// ✅ Génération de la séquence d'amorces si nécessaire
+			List<AmorceType>? amorceSequence = null;
+			if (settings.CurrentProfile.IsAmorce)
+				amorceSequence = GenerateAmorceSequence(total, settings.CurrentProfile.DominantPercent);
+
+			// ✅ Génération des trials
+			for (int i = 0; i < total; i++)
+			{
+				var trial = new StroopTrial
+				{
+					TrialNumber = i + 1,
+					Block = settings.Block,
+					ParticipantId = settings.Participant.Id,
+					IsAmorce = settings.CurrentProfile.IsAmorce,
+					SwitchPercent = settings.CurrentProfile.DominantPercent,
+					CongruencePercent = settings.CurrentProfile.CongruencePercent,
+				};
+
+				bool isCongruent = congruenceFlags[i];
+
+				if (isCongruent)
+				{
+					// Trial congruent : même couleur et même mot
+					int idx = _random.Next(wordColors.Length);
+					trial.Stimulus = new Word(wordColors[idx], wordColors[idx], wordTexts[idx]);
+					trial.IsCongruent = true;
+				}
+				else
+				{
+					// Trial incongruent : couleur différente du mot
+					var indices = Enumerable.Range(0, wordColors.Length)
+						.OrderBy(_ => _random.Next())
+						.Take(2)
+						.ToArray();
+					trial.Stimulus = new Word(wordColors[indices[0]], wordColors[indices[1]], wordTexts[indices[1]]);
+					trial.IsCongruent = false;
+				}
+
+				// ✅ Assigner l'amorce si nécessaire
+				if (amorceSequence != null)
+					trial.Amorce = amorceSequence[i];
+
+				// ✅ Déterminer la réponse attendue
+				trial.DetermineExpectedAnswer();
+
+				trials.Add(trial);
+			}
+
+			return trials;
+		}
+
+		public List<AmorceType> GenerateAmorceSequence(int count, int switchPercentage)
+		{
+			if (count <= 0)
+				throw new ArgumentException("Le nombre d'amorces doit être positif", nameof(count));
+
+			int switchCount = (count - 1) * switchPercentage / 100;
+			int noSwitchCount = (count - 1) - switchCount;
+
+			var switches = new List<bool>();
+			switches.AddRange(Enumerable.Repeat(true, switchCount));
+			switches.AddRange(Enumerable.Repeat(false, noSwitchCount));
+			switches = switches.OrderBy(_ => _random.Next()).ToList();
+
+			var sequence = new List<AmorceType>();
+			var current = _random.Next(0, 2) == 0 ? AmorceType.Round : AmorceType.Square;
+			sequence.Add(current);
+
+			foreach (var isSwitch in switches)
+			{
+				if (isSwitch)
+					current = current == AmorceType.Round ? AmorceType.Square : AmorceType.Round;
+
+				sequence.Add(current);
+			}
+
+			return sequence;
+		}
+	}
+}

--- a/StroopApp/Services/Window/IWindowManager.cs
+++ b/StroopApp/Services/Window/IWindowManager.cs
@@ -1,10 +1,11 @@
 ﻿using StroopApp.Models;
+using StroopApp.Views;
 
 namespace StroopApp.Services.Window
 {
-    public interface IWindowManager
-    {
-        void ShowParticipantWindow(ExperimentSettings settings);
-        void CloseParticipantWindow();
-    }
+	public interface IWindowManager
+	{
+		void ShowParticipantWindow(ExperimentSettings settings);
+		void CloseParticipantWindow();
+	}
 }

--- a/StroopApp/Services/Window/WindowManager.cs
+++ b/StroopApp/Services/Window/WindowManager.cs
@@ -1,31 +1,31 @@
-﻿using StroopApp.Views;
-using StroopApp.Models;
+﻿using StroopApp.Models;
+using StroopApp.Views;
 
 namespace StroopApp.Services.Window
 {
-    public class WindowManager : IWindowManager
-    {
-        private ParticipantWindow _participantWindow;
+	public class WindowManager : IWindowManager
+	{
+		private ParticipantWindow _participantWindow;
 
-        public void ShowParticipantWindow(ExperimentSettings settings)
-        {
-            if (_participantWindow == null)
-            {
-                _participantWindow = new ParticipantWindow(settings);
-                _participantWindow.Closed += (_, _) => _participantWindow = null;
-                _participantWindow.Show();
-            }
-            else
-            {
-                _participantWindow.Reset();
-                _participantWindow.Activate();
-                
-            }
-        }
-        public void CloseParticipantWindow()
-        {
-            _participantWindow?.Close();
-            _participantWindow = null;
-        }
-    }
+		public void ShowParticipantWindow(ExperimentSettings settings)
+		{
+			if (_participantWindow == null)
+			{
+				_participantWindow = new ParticipantWindow(settings);
+				_participantWindow.Closed += (_, _) => _participantWindow = null;
+				_participantWindow.Show();
+			}
+			else
+			{
+				_participantWindow.Reset();
+				_participantWindow.Activate();
+
+			}
+		}
+		public void CloseParticipantWindow()
+		{
+			_participantWindow?.Close();
+			_participantWindow = null;
+		}
+	}
 }

--- a/StroopApp/ViewModels/Configuration/ConfigurationPageViewModel.cs
+++ b/StroopApp/ViewModels/Configuration/ConfigurationPageViewModel.cs
@@ -70,7 +70,8 @@ namespace StroopApp.ViewModels.Configuration
 				ShowErrorDialog(Strings.Error_SelectParticipant);
 				return;
 			}
-
+			_settings.ExperimentContext.IsTaskStopped = false;
+			_settings.ExperimentContext.IsBlockFinished = false;
 			_settings.ExperimentContext.AddNewSerie(_settings);
 			_experimenterNavigationService.NavigateTo(() => new ExperimentDashBoardPage(_settings, _experimenterNavigationService, _windowManager));
 			_windowManager.ShowParticipantWindow(_settings);

--- a/StroopApp/ViewModels/Configuration/ConfigurationPageViewModel.cs
+++ b/StroopApp/ViewModels/Configuration/ConfigurationPageViewModel.cs
@@ -6,6 +6,7 @@ using StroopApp.Models;
 using StroopApp.Resources;
 using StroopApp.Services.Language;
 using StroopApp.Services.Navigation;
+using StroopApp.Services.Trial;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.Configuration.Participant;
 using StroopApp.ViewModels.Configuration.Profile;
@@ -22,6 +23,7 @@ namespace StroopApp.ViewModels.Configuration
 		private readonly INavigationService _experimenterNavigationService;
 		private readonly IWindowManager _windowManager;
 		private readonly ILanguageService _languageService;
+		private readonly ITrialGenerationService _trialGenerationService;
 		public ExperimentSettings _settings
 		{
 			get; set;
@@ -39,7 +41,7 @@ namespace StroopApp.ViewModels.Configuration
 								  ParticipantManagementViewModel participantViewModel,
 								  KeyMappingViewModel keyMappingViewModel,
 								  INavigationService experimenterNavigationService,
-								  IWindowManager windowManager
+								  IWindowManager windowManager, ITrialGenerationService trialGenerationService
 								  )
 		{
 			_profileViewModel = profileViewModel;
@@ -47,6 +49,7 @@ namespace StroopApp.ViewModels.Configuration
 			_keyMappingViewModel = keyMappingViewModel;
 			_experimenterNavigationService = experimenterNavigationService;
 			_windowManager = windowManager;
+			_trialGenerationService = trialGenerationService;
 			_settings = settings;
 			LaunchExperimentCommand = new RelayCommand(LaunchExperiment);
 			OpenAdvancedSettingsCommand = new RelayCommand(OpenAdvancedSettings);
@@ -73,8 +76,22 @@ namespace StroopApp.ViewModels.Configuration
 			_settings.ExperimentContext.IsTaskStopped = false;
 			_settings.ExperimentContext.IsBlockFinished = false;
 			_settings.ExperimentContext.AddNewSerie(_settings);
-			_experimenterNavigationService.NavigateTo(() => new ExperimentDashBoardPage(_settings, _experimenterNavigationService, _windowManager));
-			_windowManager.ShowParticipantWindow(_settings);
+			try
+			{
+				var trials = _trialGenerationService.GenerateTrials(_settings);
+
+				foreach (var trial in trials)
+				{
+					_settings.ExperimentContext.CurrentBlock.TrialRecords.Add(trial);
+				}
+				_experimenterNavigationService.NavigateTo(() =>
+					new ExperimentDashBoardPage(_settings, _experimenterNavigationService, _windowManager));
+				_windowManager.ShowParticipantWindow(_settings);
+			}
+			catch (Exception ex)
+			{
+				ShowErrorDialog($"Error while generating trials : {ex.Message}");
+			}
 		}
 		private void OpenAdvancedSettings()
 		{

--- a/StroopApp/ViewModels/Configuration/Participant/ParticipantManagementViewModel.cs
+++ b/StroopApp/ViewModels/Configuration/Participant/ParticipantManagementViewModel.cs
@@ -137,7 +137,7 @@ namespace StroopApp.ViewModels.Configuration.Participant
 				ShowErrorDialog(Strings.Error_SelectParticipantToDelete);
 				return;
 			}
-			if (await ShowConfirmationDialog(Strings.Message_DeleteParticipantConfirmation))
+			if (await ShowConfirmationDialog(Strings.Title_DeleteConfirmation, Strings.Message_DeleteParticipantConfirmation))
 			{
 				_participantService.DeleteParticipant(Participants, SelectedParticipant.Id);
 				SelectedParticipant = Participants.FirstOrDefault();

--- a/StroopApp/ViewModels/Configuration/Profile/ProfileManagementViewModel.cs
+++ b/StroopApp/ViewModels/Configuration/Profile/ProfileManagementViewModel.cs
@@ -104,7 +104,7 @@ namespace StroopApp.ViewModels.Configuration.Profile
 				ShowErrorDialog(Strings.Error_SelectProfileToDelete);
 				return;
 			}
-			if (await ShowConfirmationDialog(Strings.Message_DeleteProfileConfirmation))
+			if (await ShowConfirmationDialog(Strings.Title_DeleteConfirmation, Strings.Message_DeleteProfileConfirmation))
 			{
 				int currentIndex = Profiles.IndexOf(_currentProfile);
 				_profileService.DeleteProfile(_currentProfile, Profiles);

--- a/StroopApp/ViewModels/Experiment/Experimenter/End/EndExperimentPageViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/End/EndExperimentPageViewModel.cs
@@ -39,6 +39,10 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
 		{
 			get;
 		}
+		public ICommand NewExperimentCommand
+		{
+			get;
+		}
 		public ICommand ExportCommand
 		{
 			get;
@@ -77,6 +81,7 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
 			_experimenterNavigationService = experimenterNavigationService;
 			_windowManager = windowManager;
 			ContinueCommand = new RelayCommand(Continue);
+			NewExperimentCommand = new RelayCommand(NewExperiment);
 			ExportCommand = new RelayCommand(Export);
 			QuitWihtoutExportCommand = new RelayCommand(QuitWihtoutExport);
 			Blocks = Settings.ExperimentContext.Blocks;
@@ -139,6 +144,18 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
 			Settings.ExperimentContext.IsBlockFinished = false;
 			Settings.ExperimentContext.IsParticipantSelectionEnabled = false;
 			_experimenterNavigationService.NavigateTo(() => new ConfigurationPage(Settings, _experimenterNavigationService, _windowManager));
+		}
+		private async void NewExperiment()
+		{
+			bool confirmed = await ShowConfirmationDialog(Strings.Title_ConfirmNewExperiment, Strings.Message_ConfirmNewExperiment);
+			if (confirmed)
+			{
+				Settings.Reset();
+				_windowManager.CloseParticipantWindow();
+				_experimenterNavigationService.NavigateTo(() =>
+				new ConfigurationPage(Settings, _experimenterNavigationService, _windowManager));
+			}
+
 		}
 		private async void Export()
 		{

--- a/StroopApp/ViewModels/Experiment/Experimenter/End/EndExperimentPageViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/End/EndExperimentPageViewModel.cs
@@ -148,7 +148,7 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
 		private async void QuitWihtoutExport()
 		{
 
-			if (await ShowConfirmationDialog(Strings.Message_ConfirmExitWithoutExport))
+			if (await ShowConfirmationDialog(Strings.Title_ConfirmShutDown, Strings.Message_ConfirmExitWithoutExport))
 			{
 				Application.Current.Shutdown();
 			}

--- a/StroopApp/ViewModels/Experiment/Experimenter/ExperimentDashBoardPageViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/ExperimentDashBoardPageViewModel.cs
@@ -1,26 +1,61 @@
-﻿using StroopApp.Core;
+﻿using System.Threading;
+using System.Windows.Input;
+using System.Windows.Navigation;
+
+using DocumentFormat.OpenXml.Wordprocessing;
+
+using StroopApp.Core;
 using StroopApp.Models;
+using StroopApp.Resources;
 using StroopApp.Services.Navigation;
 using StroopApp.Services.Window;
 using StroopApp.Views.Experiment.Experimenter;
+using StroopApp.Views.Experiment.Participant;
 
 namespace StroopApp.ViewModels.Experiment
 {
-    public class ExperimentDashBoardPageViewModel : ViewModelBase
-    {
-        readonly SharedExperimentData _experimentContext;
-        public ExperimentDashBoardPageViewModel( ExperimentSettings settings, INavigationService experimenterNavigationService, IWindowManager windowManager)
-        {
-            _experimentContext = settings.ExperimentContext;
-            _experimentContext.PropertyChanged += (s, e) =>
-            {
-                if (e.PropertyName == nameof(_experimentContext.IsBlockFinished)
-                    && _experimentContext.IsBlockFinished)
-                {
-                    experimenterNavigationService.NavigateTo(
-                        () => new EndExperimentPage(settings, experimenterNavigationService, windowManager));
-                }
-            };
-        }
-    }
+	public class ExperimentDashBoardPageViewModel : ViewModelBase
+	{
+		readonly ExperimentSettings _settings;
+		readonly INavigationService _experimenterNavigationService;
+		readonly SharedExperimentData _experimentContext;
+		readonly IWindowManager _windowManager;
+
+		public ICommand StopTaskCommand
+		{
+			get;
+		}
+		public ExperimentDashBoardPageViewModel(ExperimentSettings settings, INavigationService experimenterNavigationService, IWindowManager windowManager)
+		{
+			_settings = settings;
+			_experimentContext = settings.ExperimentContext;
+			_experimenterNavigationService = experimenterNavigationService;
+			_windowManager = windowManager;
+			_experimentContext.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(_experimentContext.IsBlockFinished)
+					&& _experimentContext.IsBlockFinished)
+				{
+					_experimenterNavigationService.NavigateTo(
+						() => new EndExperimentPage(_settings, _experimenterNavigationService, _windowManager));
+				}
+			};
+			StopTaskCommand = new RelayCommand(async _ => await StopTaskAsync());
+		}
+		async public Task StopTaskAsync()
+		{
+			bool confirmed = await ShowConfirmationDialog(Strings.Title_ConfirmStopTask, Strings.Message_StopTask);
+			if (confirmed)
+			{
+				_settings.ExperimentContext.IsTaskStopped = true;
+				if (_experimentContext.CurrentBlock != null)
+				{
+					_experimentContext.CurrentBlock.CalculateValues();
+					_experimentContext.CurrentTrial = null;
+
+				}
+				_experimentContext.IsBlockFinished = true;
+			}
+		}
+	}
 }

--- a/StroopApp/ViewModels/Experiment/Experimenter/GlobalGraphViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/GlobalGraphViewModel.cs
@@ -32,9 +32,7 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.Graphs
 		{
 			Series = settings.ExperimentContext.BlockSeries;
 			Sections = settings.ExperimentContext.Sections;
-			var totalTrials = settings.ExperimentContext.Blocks.Sum(b => b.TrialRecords.Count()) + settings.CurrentProfile.WordCount;
-			if (settings.ExperimentContext.IsBlockFinished)
-				totalTrials -= settings.CurrentProfile.WordCount;
+			var totalTrials = settings.ExperimentContext.Blocks.Sum(b => b.TrialRecords.Count());
 			XAxes = new[]
 			{
 				new Axis

--- a/StroopApp/ViewModels/Experiment/Participant/InstructionsPageViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Participant/InstructionsPageViewModel.cs
@@ -17,7 +17,7 @@ namespace StroopApp.ViewModels.Experiment.Participant
 	public class InstructionsPageViewModel : ViewModelBase
 	{
 		private readonly ExperimentSettings _settings;
-		private readonly INavigationService _navigationService;
+		private readonly INavigationService _participantWindowNavigationService;
 		private int _currentPageIndex;
 		private const int TotalPages = 3;
 
@@ -26,11 +26,11 @@ namespace StroopApp.ViewModels.Experiment.Participant
 		public event EventHandler InstructionChanged;
 		public StroopPage StroopPage { get; set; }
 
-		public InstructionsPageViewModel(ExperimentSettings settings, INavigationService navigationService)
+		public InstructionsPageViewModel(ExperimentSettings settings, INavigationService participantWindowNavigationService)
 		{
 			_currentPageIndex = 0;
 			_settings = settings;
-			_navigationService = navigationService;
+			_participantWindowNavigationService = participantWindowNavigationService;
 			NextCommand = new RelayCommand(_ => NextPage());
 			CurrentInstruction = GenerateInstructionPage(_currentPageIndex);
 		}
@@ -45,8 +45,8 @@ namespace StroopApp.ViewModels.Experiment.Participant
 			}
 			else
 			{
-				StroopPage = new StroopPage(_navigationService, _settings);
-				_navigationService.NavigateTo(() => StroopPage);
+				StroopPage = new StroopPage(_participantWindowNavigationService, _settings);
+				_participantWindowNavigationService.NavigateTo(() => StroopPage);
 			}
 		}
 

--- a/StroopApp/ViewModels/Experiment/Participant/ParticipantWindowViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Participant/ParticipantWindowViewModel.cs
@@ -1,15 +1,43 @@
 ﻿using DocumentFormat.OpenXml.Wordprocessing;
+
 using StroopApp.Models;
 using StroopApp.Services.Navigation;
 using StroopApp.Views.Experiment.Participant;
 
 namespace StroopApp.ViewModels.Experiment.Participant
 {
-    public class ParticipantWindowViewModel
-    {
-        public ParticipantWindowViewModel(ExperimentSettings settings, INavigationService participantWindowNavigationService)
-        {
-            participantWindowNavigationService.NavigateTo(() => new InstructionsPage(settings, participantWindowNavigationService));
-        }
-    }
+	public class ParticipantWindowViewModel
+	{
+		private readonly ExperimentSettings _settings;
+		private readonly INavigationService _participantWindowNavigationService;
+
+		public ParticipantWindowViewModel(ExperimentSettings settings, INavigationService participantWindowNavigationService)
+		{
+			_settings = settings;
+			_participantWindowNavigationService = participantWindowNavigationService;
+
+
+			_settings.ExperimentContext.PropertyChanged += ExperimentContext_PropertyChanged;
+
+
+			participantWindowNavigationService.NavigateTo(() => new InstructionsPage(settings, participantWindowNavigationService));
+		}
+
+		private void ExperimentContext_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+
+			if (e.PropertyName == nameof(_settings.ExperimentContext.IsBlockFinished)
+				&& _settings.ExperimentContext.IsBlockFinished)
+			{
+				_participantWindowNavigationService.NavigateTo(() => new EndInstructionsPage());
+			}
+		}
+		public void Dispose()
+		{
+			if (_settings?.ExperimentContext != null)
+			{
+				_settings.ExperimentContext.PropertyChanged -= ExperimentContext_PropertyChanged;
+			}
+		}
+	}
 }

--- a/StroopApp/ViewModels/Experiment/Participant/Stroop/StroopViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Participant/Stroop/StroopViewModel.cs
@@ -1,11 +1,12 @@
-﻿// StroopViewModel.cs
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
+
+using DocumentFormat.OpenXml.Wordprocessing;
 
 using StroopApp.Core;
 using StroopApp.Models;
@@ -40,15 +41,19 @@ public class StroopViewModel : ViewModelBase
 	private TaskCompletionSource<double> _inputTcs;
 	private readonly Stopwatch _responseTime;
 	private readonly Stopwatch _wordTimer;
-	private readonly INavigationService _navigationService;
+	private readonly INavigationService _participantWindowNavigationService;
 	private readonly Random random = new Random();
+	private CancellationTokenSource _cancellationTokenSource;
+	private bool _isDisposed = false;
 
-	public StroopViewModel(ExperimentSettings settings, INavigationService navigationService)
+	public StroopViewModel(ExperimentSettings settings, INavigationService participantWindowNavigationService)
 	{
 		Settings = settings;
-		_navigationService = navigationService;
+		_participantWindowNavigationService = participantWindowNavigationService;
 		_responseTime = new Stopwatch();
 		_wordTimer = new Stopwatch();
+		_cancellationTokenSource = new CancellationTokenSource();
+
 		GenerateTrials();
 		StartTrials();
 	}
@@ -153,62 +158,128 @@ public class StroopViewModel : ViewModelBase
 
 	public async void StartTrials()
 	{
-		foreach (var trial in Settings.ExperimentContext.CurrentBlock.TrialRecords)
+		try
 		{
-			Settings.ExperimentContext.CurrentTrial = trial;
-
-			CurrentControl = new FixationCrossControl();
-			await Task.Delay(Settings.CurrentProfile.FixationDuration);
-			if (Settings.CurrentProfile.IsAmorce)
+			foreach (var trial in Settings.ExperimentContext.CurrentBlock.TrialRecords)
 			{
-				CurrentControl = new AmorceControl(trial.Amorce);
-				await Task.Delay(Settings.CurrentProfile.AmorceDuration);
-			}
+				if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
+				{
+					HandleTaskStopped();
+					return;
+				}
+				Settings.ExperimentContext.CurrentTrial = trial;
 
-			var wordControl = new WordControl(trial.Stimulus.Text, trial.Stimulus.Color);
-			CurrentControl = wordControl;
-
-			await Application.Current.Dispatcher.BeginInvoke(new Action(() =>
-			{
-				_responseTime.Restart();
-				_wordTimer.Restart();
-				_inputTcs = new TaskCompletionSource<double>();
-			}), DispatcherPriority.Render);
-
-			var delayTask = Task.Delay(Settings.CurrentProfile.MaxReactionTime);
-			var completed = await Task.WhenAny(_inputTcs.Task, delayTask);
-
-			if (completed == _inputTcs.Task)
-			{
-				_responseTime.Stop();
-				trial.ReactionTime = _inputTcs.Task.Result;
-				Settings.ExperimentContext.CurrentBlock.TrialTimes.Add(trial.ReactionTime);
-				Settings.ExperimentContext.ReactionPoints.Add(new ReactionTimePoint(trial.TrialNumber, trial.ReactionTime, trial.IsValidResponse));
 				CurrentControl = new FixationCrossControl();
-			}
-			else
-			{
-				_responseTime.Stop();
-				_inputTcs.TrySetCanceled();
-				Settings.ExperimentContext.CurrentBlock.TrialTimes.Add(null);
-				Settings.ExperimentContext.ReactionPoints.Add(new ReactionTimePoint(trial.TrialNumber, double.NaN, null));
+				await Task.Delay(Settings.CurrentProfile.FixationDuration, _cancellationTokenSource.Token);
+				if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
+				{
+					HandleTaskStopped();
+					return;
+				}
+				if (Settings.CurrentProfile.IsAmorce)
+				{
+					CurrentControl = new AmorceControl(trial.Amorce);
+					await Task.Delay(Settings.CurrentProfile.AmorceDuration, _cancellationTokenSource.Token);
+
+					if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
+					{
+						HandleTaskStopped();
+						return;
+					}
+				}
+
+				var wordControl = new WordControl(trial.Stimulus.Text, trial.Stimulus.Color);
+				CurrentControl = wordControl;
+
+				await Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+				{
+					if (!_isDisposed)
+					{
+						_responseTime.Restart();
+						_wordTimer.Restart();
+						_inputTcs = new TaskCompletionSource<double>();
+					}
+				}), DispatcherPriority.Render);
+
+				if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
+				{
+					HandleTaskStopped();
+					return;
+				}
+
+				var delayTask = Task.Delay(Settings.CurrentProfile.MaxReactionTime, _cancellationTokenSource.Token);
+				var completed = await Task.WhenAny(_inputTcs.Task, delayTask);
+
+				if (completed == _inputTcs.Task && !_inputTcs.Task.IsCanceled)
+				{
+					_responseTime.Stop();
+					trial.ReactionTime = _inputTcs.Task.Result;
+					Settings.ExperimentContext.CurrentBlock.TrialTimes.Add(trial.ReactionTime);
+					Settings.ExperimentContext.ReactionPoints.Add(new ReactionTimePoint(trial.TrialNumber, trial.ReactionTime, trial.IsValidResponse));
+					CurrentControl = new FixationCrossControl();
+				}
+				else if (!delayTask.IsCanceled)
+				{
+					_responseTime.Stop();
+					_inputTcs.TrySetCanceled();
+					Settings.ExperimentContext.CurrentBlock.TrialTimes.Add(null);
+					Settings.ExperimentContext.ReactionPoints.Add(new ReactionTimePoint(trial.TrialNumber, double.NaN, null));
+				}
+
+				if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
+				{
+					HandleTaskStopped();
+					return;
+				}
+
+				double remaining = Settings.CurrentProfile.MaxReactionTime - _wordTimer.Elapsed.TotalMilliseconds;
+				if (remaining > 0)
+					await Task.Delay((int)remaining, _cancellationTokenSource.Token);
+
+				_wordTimer.Stop();
 			}
 
-			double remaining = Settings.CurrentProfile.MaxReactionTime - _wordTimer.Elapsed.TotalMilliseconds;
-			if (remaining > 0)
-				await Task.Delay((int)remaining);
-
-			_wordTimer.Stop();
+			EndBlock();
 		}
-
-		EndBlock();
+		catch (OperationCanceledException)
+		{
+			// Stop
+			HandleTaskStopped();
+		}
+	}
+	public void StopTask()
+	{
+		Settings.ExperimentContext.IsTaskStopped = true;
+		_cancellationTokenSource?.Cancel();
 	}
 
+	public void Dispose()
+	{
+		if (!_isDisposed)
+		{
+			_isDisposed = true;
+			StopTask();
+			_cancellationTokenSource?.Dispose();
+		}
+	}
+	private void HandleTaskStopped()
+	{
+		_responseTime.Stop();
+		_wordTimer.Stop();
+		_inputTcs?.TrySetCanceled();
+
+		if (Settings.ExperimentContext.CurrentBlock != null)
+		{
+			Settings.ExperimentContext.CurrentBlock.CalculateValues();
+		}
+
+		Settings.ExperimentContext.CurrentTrial = null;
+		Settings.ExperimentContext.IsBlockFinished = true;
+	}
 	public void EndBlock()
 	{
 		Settings.ExperimentContext.CurrentBlock.CalculateValues();
 		Settings.ExperimentContext.CurrentTrial = null;
-		_navigationService.NavigateTo(() => new EndInstructionsPage());
 		Settings.ExperimentContext.IsBlockFinished = true;
 	}
 

--- a/StroopApp/Views/Configuration/ConfigurationPage.xaml.cs
+++ b/StroopApp/Views/Configuration/ConfigurationPage.xaml.cs
@@ -8,6 +8,7 @@ using StroopApp.Services.Language;
 using StroopApp.Services.Navigation;
 using StroopApp.Services.Participants;
 using StroopApp.Services.Profile;
+using StroopApp.Services.Trial;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.Configuration;
 using StroopApp.ViewModels.Configuration.Participant;
@@ -32,6 +33,7 @@ namespace StroopApp.Views
 			var exportFolderStorageService = new ExportationService(settings, configDir);
 			var participantService = new ParticipantService(configDir, settings);
 			var keyMappingService = new KeyMappingService(configDir);
+			var trialGenerationService = new TrialGenerationService();
 
 			// Instanciation unique des ViewModels
 			var profileViewModel = new ProfileManagementViewModel(profileService);
@@ -40,7 +42,7 @@ namespace StroopApp.Views
 			var exportFolderSelectorViewModel = new ExportFolderSelectorViewModel(settings, exportFolderStorageService);
 
 			// Instanciation du ViewModel principal et liaison au DataContext
-			DataContext = new ConfigurationPageViewModel(settings, profileViewModel, participantViewModel, keyMappingViewModel, experimentNavigationService, windowManager);
+			DataContext = new ConfigurationPageViewModel(settings, profileViewModel, participantViewModel, keyMappingViewModel, experimentNavigationService, windowManager, trialGenerationService);
 
 			// Instanciation des vues en injectant les ViewModels partagés
 			var profileManagementView = new ProfileManagementView(profileViewModel);

--- a/StroopApp/Views/Experiment/Experimenter/End/EndExperimentPage.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/End/EndExperimentPage.xaml
@@ -194,6 +194,8 @@
                     Command="{Binding ContinueCommand}" />
             <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Export]}"
                     Command="{Binding ExportCommand}" />
+            <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_NewExperiment]}" 
+                    Command="{Binding NewExperimentCommand}"/>
             <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_Quit_Without_Export]}"
                     Command="{Binding QuitWihtoutExportCommand}" />
         </ui:SimpleStackPanel>

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml
@@ -1,18 +1,35 @@
 ﻿<Page x:Class="StroopApp.Views.ExperimentDashBoardPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:ui="http://schemas.modernwpf.com/2019"
       Title="ExperimentDashBoardPage">
-    <Grid x:Name="MainGrid" Margin="12">
+    <Grid x:Name="MainGrid"
+          Margin="12">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="12" />
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0"
-                   Text="{Binding Source={StaticResource Loc}, Path=[Title_Dashboard]}"
-                   Style="{DynamicResource HeaderTextBlockStyle}"
-                   HorizontalAlignment="Left"
-                   Margin="0,0,0,12" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Title_Dashboard]}"
+                       Style="{DynamicResource HeaderTextBlockStyle}"
+                       HorizontalAlignment="Left"
+                       Margin="0,0,0,12" />
+            <Button 
+                Grid.Column="1"
+                Content="{Binding Source={StaticResource Loc}, Path=[Button_StopTask]}"
+                    Style="{DynamicResource AccentButtonStyle}"
+                    Command="{Binding StopTaskCommand}"
+                    ToolTip="{Binding Source={StaticResource Loc}, Path=[Tooltip_StopTask]}" />
+        </Grid>
     </Grid>
 </Page>

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml.cs
@@ -1,25 +1,26 @@
-﻿using StroopApp.Models;
+﻿using System.Windows.Controls;
+
+using StroopApp.Models;
 using StroopApp.Services.Navigation;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.Experiment;
 using StroopApp.Views.Experiment.Experimenter;
 using StroopApp.Views.Experiment.Experimenter.Graphs;
-using System.Windows.Controls;
 
 namespace StroopApp.Views
 {
-    public partial class ExperimentDashBoardPage : Page
-    {
-        public ExperimentDashBoardPage(ExperimentSettings settings, INavigationService experimenterNavigationService, IWindowManager windowManager)
-        {
-            InitializeComponent();
-            var ExperimentProfileView = new ExperimentProgressView(settings);
-            var GraphsView = new GraphsView(settings);
-            DataContext = new ExperimentDashBoardPageViewModel(settings, experimenterNavigationService, windowManager);
-            MainGrid.Children.Add(ExperimentProfileView);
-            Grid.SetRow(ExperimentProfileView, 1);
-            MainGrid.Children.Add(GraphsView);
-            Grid.SetRow(GraphsView, 3);
-        }
-    }
+	public partial class ExperimentDashBoardPage : Page
+	{
+		public ExperimentDashBoardPage(ExperimentSettings settings, INavigationService experimenterNavigationService, IWindowManager windowManager)
+		{
+			InitializeComponent();
+			var ExperimentProfileView = new ExperimentProgressView(settings);
+			var GraphsView = new GraphsView(settings);
+			DataContext = new ExperimentDashBoardPageViewModel(settings, experimenterNavigationService, windowManager);
+			MainGrid.Children.Add(ExperimentProfileView);
+			Grid.SetRow(ExperimentProfileView, 1);
+			MainGrid.Children.Add(GraphsView);
+			Grid.SetRow(GraphsView, 3);
+		}
+	}
 }

--- a/StroopApp/Views/Experiment/Participant/Stroop/StroopPage.xaml.cs
+++ b/StroopApp/Views/Experiment/Participant/Stroop/StroopPage.xaml.cs
@@ -1,27 +1,28 @@
 ﻿// StroopPage.xaml.cs
-using StroopApp.Models;
-using StroopApp.Services.Navigation;
 using System.Windows.Controls;
 using System.Windows.Input;
 
+using StroopApp.Models;
+using StroopApp.Services.Navigation;
+
 namespace StroopApp.Views.Experiment.Participant
 {
-    public partial class StroopPage : Page
-    {
-        private readonly StroopViewModel _viewModel;
+	public partial class StroopPage : Page
+	{
+		private readonly StroopViewModel _viewModel;
 
-        public StroopPage(INavigationService navigationService, ExperimentSettings settings)
-        {
-            InitializeComponent();
-            _viewModel = new StroopViewModel(settings, navigationService);
-            DataContext = _viewModel;
-            this.KeyDown += StroopPage_KeyDown;
-            Loaded += (s, e) => Keyboard.Focus(this);
-        }
+		public StroopPage(INavigationService participantWindowNavigationService, ExperimentSettings settings)
+		{
+			InitializeComponent();
+			_viewModel = new StroopViewModel(settings, participantWindowNavigationService);
+			DataContext = _viewModel;
+			this.KeyDown += StroopPage_KeyDown;
+			Loaded += (s, e) => Keyboard.Focus(this);
+		}
 
-        private void StroopPage_KeyDown(object sender, KeyEventArgs e)
-        {
-            _viewModel.ProcessInput(e.Key);
-        }
-    }
+		private void StroopPage_KeyDown(object sender, KeyEventArgs e)
+		{
+			_viewModel.ProcessInput(e.Key);
+		}
+	}
 }

--- a/StroopApp/Views/ParticipantWindow.xaml.cs
+++ b/StroopApp/Views/ParticipantWindow.xaml.cs
@@ -1,27 +1,33 @@
-﻿using StroopApp.Models;
+﻿using System.Windows;
+
+using StroopApp.Models;
 using StroopApp.Services.Navigation;
 using StroopApp.ViewModels.Experiment.Participant;
-using System.Windows;
 
 namespace StroopApp.Views
 {
-    public partial class ParticipantWindow : Window
-    {
-        private readonly ExperimentSettings _settings;
-        private readonly INavigationService _participantWindowNavigationService;
-        public ParticipantWindow(ExperimentSettings Settings)
-        {
-            InitializeComponent();
-            _participantWindowNavigationService = new NavigationService(ParticipantFrame);
-            DataContext = new ParticipantWindowViewModel(Settings, _participantWindowNavigationService);
-            _settings = Settings;
-        }
+	public partial class ParticipantWindow : Window
+	{
+		private readonly ExperimentSettings _settings;
+		private readonly INavigationService _participantWindowNavigationService;
+		public ParticipantWindow(ExperimentSettings Settings)
+		{
+			InitializeComponent();
+			_participantWindowNavigationService = new NavigationService(ParticipantFrame);
+			DataContext = new ParticipantWindowViewModel(Settings, _participantWindowNavigationService);
+			_settings = Settings;
+		}
 
 
 
-        public void Reset()
-        {
-            DataContext = new ParticipantWindowViewModel(_settings, _participantWindowNavigationService);
-        }
-    }
+		public void Reset()
+		{
+			if (DataContext is ParticipantWindowViewModel oldViewModel)
+			{
+				oldViewModel.Dispose();
+			}
+
+			DataContext = new ParticipantWindowViewModel(_settings, _participantWindowNavigationService);
+		}
+	}
 }


### PR DESCRIPTION
## Interrupt experiment during task + UI/UX improvements

This PR adds the ability to **stop an ongoing experiment**, improves dialog handling, and enhances localization and UI/UX throughout the app.

### Main changes

* **Task interruption**

  * Add `IsTaskStopped` in `SharedExperimentData` and handle experiment stop logic in `StroopViewModel` with `CancellationTokenSource`.
  * Add `StopTaskCommand` to `ExperimentDashBoardPageViewModel` and integrate into the dashboard UI.
  * Confirmation dialogs for stopping an experiment (with localized messages).
* **Dialogs & confirmation**

  * `ShowConfirmationDialog` in `ViewModelBase` now accepts a `title` parameter.
  * Updated all usages to ensure clearer confirmation messages.
* **UI/UX**

  * XAML and ViewModel updates for a better user flow during experiment interruption.
  * Improved dialog and button texts with resource strings.
  * Interface cleanup in `IWindowManager` and `WindowManager`.
* **Localization**

  * New and updated resource strings in all relevant `.resx` files.
* **Code structure**

  * Refactoring for clarity, state initialization, and naming.
  * Removed obsolete logic, improved separation of concerns.

---

**All new features and changes tested locally.**

---
