### PR TITLE
refactor(ui): implement DataTemplates and modularize ViewModels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Run tests
+        run: dotnet test StroopApp.XUnitTests/StroopApp.XUnitTests.csproj --configuration Release --no-restore
+
+      - name: Publish
+        run: >
+          dotnet publish StroopApp/StroopApp.csproj
+          --configuration Release
+          --runtime win-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          --output ./publish
+
+      - name: Zip artifact
+        run: Compress-Archive -Path ./publish/* -DestinationPath StroopApp-${{ github.ref_name }}-win-x64.zip
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: StroopApp-${{ github.ref_name }}-win-x64.zip
+          generate_release_notes: true

--- a/StroopApp.XUnitTests/ViewModels/Configuration/ConfigurationPageViewModelTests.cs
+++ b/StroopApp.XUnitTests/ViewModels/Configuration/ConfigurationPageViewModelTests.cs
@@ -35,11 +35,15 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 
 			var keyMappingViewModel = new KeyMappingViewModel(dummyKeyMappingService);
 
+			var dummyExportationService = new DummyExportationService();
+			var exportFolderSelectorViewModel = new ExportFolderSelectorViewModel(settings, dummyExportationService);
+
 			var viewModel = new TestableConfigurationPageViewModel(
 				settings,
 				profileViewModel,
 				participantViewModel,
 				keyMappingViewModel,
+				exportFolderSelectorViewModel,
 				dummyNavigationService,
 				dummyWindowManager,
 				dummyTrialGenerationService, 
@@ -79,11 +83,15 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
 
 			var keyMappingViewModel = new KeyMappingViewModel(dummyKeyMappingService);
 
+			var dummyExportationService = new DummyExportationService();
+			var exportFolderSelectorViewModel = new ExportFolderSelectorViewModel(settings, dummyExportationService);
+
 			var viewModel = new TestableConfigurationPageViewModel(
 				settings,
 				profileViewModel,
 				participantViewModel,
 				keyMappingViewModel,
+				exportFolderSelectorViewModel,
 				dummyNavigationService,
 				dummyWindowManager,
 				dummyTrialGenerationService, 

--- a/StroopApp.XUnitTests/ViewModels/Configuration/TestableConfigurationPageViewModel.cs
+++ b/StroopApp.XUnitTests/ViewModels/Configuration/TestableConfigurationPageViewModel.cs
@@ -19,11 +19,12 @@ namespace StroopApp.XUnitTests.ViewModels.Configuration
             ProfileManagementViewModel profileViewModel,
             ParticipantManagementViewModel participantViewModel,
             KeyMappingViewModel keyMappingViewModel,
+            ExportFolderSelectorViewModel exportFolderSelectorViewModel,
             INavigationService experimenterNavigationService,
             IWindowManager windowManager,
             ITrialGenerationService trialGenerationService,
             ILanguageService languageService
-        ) : base(settings, profileViewModel, participantViewModel, keyMappingViewModel, experimenterNavigationService, windowManager, trialGenerationService, languageService)
+        ) : base(settings, profileViewModel, participantViewModel, keyMappingViewModel, exportFolderSelectorViewModel, experimenterNavigationService, windowManager, trialGenerationService, languageService)
         { }
 
         protected override Task ShowErrorDialogAsync(string message)

--- a/StroopApp/App.xaml
+++ b/StroopApp/App.xaml
@@ -11,6 +11,7 @@
                                    AccentColor="CornflowerBlue" />
                 <ui:XamlControlsResources />
                 <ResourceDictionary Source="Resources/styles.xaml" />
+                <ResourceDictionary Source="Resources/DataTemplates.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <loc:LocalizedStrings x:Key="Loc" />
         </ResourceDictionary>

--- a/StroopApp/Resources/DataTemplates.xaml
+++ b/StroopApp/Resources/DataTemplates.xaml
@@ -1,0 +1,76 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:stroopVm="clr-namespace:StroopApp.ViewModels.Experiment.Participant.Stroop"
+                    xmlns:stroopViews="clr-namespace:StroopApp.Views.Experiment.Participant.Stroop"
+                    xmlns:configVmProfile="clr-namespace:StroopApp.ViewModels.Configuration.Profile"
+                    xmlns:configVmParticipant="clr-namespace:StroopApp.ViewModels.Configuration.Participant"
+                    xmlns:configVm="clr-namespace:StroopApp.ViewModels.Configuration"
+                    xmlns:profileViews="clr-namespace:StroopApp.Views.Profile"
+                    xmlns:participantViews="clr-namespace:StroopApp.Views.Participant"
+                    xmlns:keyMappingViews="clr-namespace:StroopApp.Views.KeyMapping"
+                    xmlns:configViews="clr-namespace:StroopApp.Views.Configuration"
+                    xmlns:experimenterVm="clr-namespace:StroopApp.ViewModels.Experiment.Experimenter"
+                    xmlns:experimenterViews="clr-namespace:StroopApp.Views.Experiment.Experimenter"
+                    xmlns:graphViews="clr-namespace:StroopApp.Views.Experiment.Experimenter.Graphs">
+
+    <!-- FixationCrossViewModel -->
+    <DataTemplate DataType="{x:Type stroopVm:FixationCrossViewModel}">
+        <stroopViews:FixationCrossControl />
+    </DataTemplate>
+
+    <!-- WordControlViewModel-->
+    <DataTemplate DataType="{x:Type stroopVm:WordControlViewModel}">
+        <stroopViews:WordControl />
+    </DataTemplate>
+
+    <!-- VisualCueControlViewModel -->
+    <DataTemplate DataType="{x:Type stroopVm:VisualCueControlViewModel}">
+        <stroopViews:VisualCueControl />
+    </DataTemplate>
+
+    <!-- ProfileManagementViewModel -->
+    <DataTemplate DataType="{x:Type configVmProfile:ProfileManagementViewModel}">
+        <profileViews:ProfileManagementView />
+    </DataTemplate>
+
+    <!-- ParticipantManagementViewModel -->
+    <DataTemplate DataType="{x:Type configVmParticipant:ParticipantManagementViewModel}">
+        <participantViews:ParticipantManagementView />
+    </DataTemplate>
+
+    <!-- KeyMappingViewModel -->
+    <DataTemplate DataType="{x:Type configVm:KeyMappingViewModel}">
+        <keyMappingViews:KeyMappingView />
+    </DataTemplate>
+
+    <!-- ExportFolderSelectorViewModel -->
+    <DataTemplate DataType="{x:Type configVm:ExportFolderSelectorViewModel}">
+        <configViews:ExportFolderSelectorView />
+    </DataTemplate>
+
+    <!-- ExperimentProgressViewModel -->
+    <DataTemplate DataType="{x:Type experimenterVm:ExperimentProgressViewModel}">
+        <experimenterViews:ExperimentProgressView />
+    </DataTemplate>
+
+    <!-- GraphsViewModel -->
+    <DataTemplate DataType="{x:Type experimenterVm:GraphsViewModel}">
+        <graphViews:GraphsView />
+    </DataTemplate>
+
+    <!-- ColumnGraphViewModel -->
+    <DataTemplate DataType="{x:Type experimenterVm:ColumnGraphViewModel}">
+        <graphViews:ColumnGraphView />
+    </DataTemplate>
+
+    <!-- GlobalGraphViewModel -->
+    <DataTemplate DataType="{x:Type experimenterVm:GlobalGraphViewModel}">
+        <graphViews:GlobalGraphView />
+    </DataTemplate>
+
+    <!-- LiveReactionTimeViewModel -->
+    <DataTemplate DataType="{x:Type experimenterVm:LiveReactionTimeViewModel}">
+        <graphViews:LiveReactionTimeView />
+    </DataTemplate>
+
+</ResourceDictionary>

--- a/StroopApp/StroopApp.csproj
+++ b/StroopApp/StroopApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿ <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net8.0-windows</TargetFramework>
@@ -6,10 +6,10 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
-		
-		<Version>1.0.0</Version>
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>1.0.0.0</FileVersion>
+
+		<Version>1.1.0</Version>
+		<AssemblyVersion>1.1.0.0</AssemblyVersion>
+		<FileVersion>1.1.0.0</FileVersion>
 		<Company>Mylan Beghin</Company>
 		<Authors>Mylan Beghin</Authors>
 		<Product>StroopApp</Product>

--- a/StroopApp/ViewModels/Configuration/ConfigurationPageViewModel.cs
+++ b/StroopApp/ViewModels/Configuration/ConfigurationPageViewModel.cs
@@ -19,9 +19,11 @@ namespace StroopApp.ViewModels.Configuration
     /// </summary>
     public partial class ConfigurationPageViewModel : ViewModelBase
     {
-        private readonly ProfileManagementViewModel _profileViewModel;
-        private readonly ParticipantManagementViewModel _participantViewModel;
-        private readonly KeyMappingViewModel _keyMappingViewModel;
+        public ProfileManagementViewModel ProfileViewModel { get; }
+        public ParticipantManagementViewModel ParticipantViewModel { get; }
+        public KeyMappingViewModel KeyMappingViewModel { get; }
+        public ExportFolderSelectorViewModel ExportFolderSelectorViewModel { get; }
+
         private readonly INavigationService _experimenterNavigationService;
         private readonly IWindowManager _windowManager;
         private readonly ILanguageService _languageService;
@@ -33,14 +35,16 @@ namespace StroopApp.ViewModels.Configuration
                                   ProfileManagementViewModel profileViewModel,
                                   ParticipantManagementViewModel participantViewModel,
                                   KeyMappingViewModel keyMappingViewModel,
+                                  ExportFolderSelectorViewModel exportFolderSelectorViewModel,
                                   INavigationService experimenterNavigationService,
                                   IWindowManager windowManager,
                                   ITrialGenerationService trialGenerationService,
                                   ILanguageService languageService)
         {
-            _profileViewModel = profileViewModel;
-            _participantViewModel = participantViewModel;
-            _keyMappingViewModel = keyMappingViewModel;
+            ProfileViewModel = profileViewModel;
+            ParticipantViewModel = participantViewModel;
+            KeyMappingViewModel = keyMappingViewModel;
+            ExportFolderSelectorViewModel = exportFolderSelectorViewModel;
             _experimenterNavigationService = experimenterNavigationService;
             _windowManager = windowManager;
             _trialGenerationService = trialGenerationService;
@@ -53,9 +57,9 @@ namespace StroopApp.ViewModels.Configuration
         {
             try
             {
-                _settings.CurrentProfile = _profileViewModel.CurrentProfile;
-                _settings.Participant = _participantViewModel.SelectedParticipant;
-                _settings.KeyMappings = _keyMappingViewModel.Mappings;
+                _settings.CurrentProfile = ProfileViewModel.CurrentProfile;
+                _settings.Participant = ParticipantViewModel.SelectedParticipant;
+                _settings.KeyMappings = KeyMappingViewModel.Mappings;
 
                 if (_settings.CurrentProfile == null)
                 {

--- a/StroopApp/ViewModels/Experiment/Experimenter/End/EndExperimentPageViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/End/EndExperimentPageViewModel.cs
@@ -8,6 +8,7 @@ using StroopApp.Services.Exportation;
 using StroopApp.Services.Navigation;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.State;
+using StroopApp.ViewModels.Experiment.Experimenter;
 using StroopApp.Views;
 using StroopApp.Views.Experiment.Experimenter.End;
 using System.Collections.ObjectModel;
@@ -19,10 +20,12 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
     /// ViewModel for the end-of-experiment page, handling continuation to next block, 
     /// starting new experiments, data export, and application shutdown with confirmations.
     /// </summary>
-    public partial class EndExperimentPageViewModel : ViewModelBase
+    public partial class EndExperimentPageViewModel : ViewModelBase, IDisposable
     {
         public ExperimentSettingsViewModel Settings { get; }
         public ObservableCollection<Block> Blocks { get; }
+        public GlobalGraphViewModel GlobalGraphViewModel { get; }
+        public LiveReactionTimeViewModel LiveReactionTimeViewModel { get; }
 
         private readonly IExportationService _exportationService;
         private readonly INavigationService _experimenterNavigationService;
@@ -47,6 +50,8 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
             _chartFactory = new ExperimentChartFactory();
 
             Blocks = Settings.ExperimentContext.Blocks;
+            GlobalGraphViewModel = new GlobalGraphViewModel(settings);
+            LiveReactionTimeViewModel = new LiveReactionTimeViewModel(settings);
             CurrentParticipant = string.Format(Strings.Label_CurrentParticipant, Settings.Participant.Id);
             CurrentProfile = string.Format(Strings.Label_CurrentProfile, Settings.CurrentProfile.ProfileName);
 
@@ -60,7 +65,7 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
         }
 
         [RelayCommand]
-        private void Continue()
+        private async Task Continue()
         {
             try
             {
@@ -75,7 +80,7 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error in Continue: {ex.Message}");
+                await ShowErrorDialogAsync($"{Strings.Error_Title}: {ex.Message}");
             }
         }
 
@@ -142,6 +147,10 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
             {
                 await ShowErrorDialogAsync($"{Strings.Error_Title}: {ex.Message}");
             }
+        }
+        public void Dispose()
+        {
+            LiveReactionTimeViewModel.Dispose();
         }
     }
 }

--- a/StroopApp/ViewModels/Experiment/Experimenter/End/ExportEndExperimentWindowViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/End/ExportEndExperimentWindowViewModel.cs
@@ -6,6 +6,7 @@ using StroopApp.Resources;
 using StroopApp.Services.Exportation;
 using StroopApp.Services.Navigation;
 using StroopApp.ViewModels.State;
+using StroopApp.ViewModels.Configuration;
 using StroopApp.Views;
 using System.Diagnostics;
 using System.IO;
@@ -50,6 +51,8 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
         [ObservableProperty]
         private string _errorMessage = string.Empty;
 
+        public ExportFolderSelectorViewModel ExportFolderSelectorViewModel { get; }
+
         public ExportEndExperimentWindowViewModel(ExperimentSettingsViewModel settings, IExportationService exportationService, Action closeWindow, Action<bool?> setDialogResult, INavigationService navigationService)
         {
             _settings = settings;
@@ -58,8 +61,14 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
             _setDialogResult = setDialogResult;
             _navigationService = navigationService;
 
+            ExportFolderSelectorViewModel = new ExportFolderSelectorViewModel(settings, exportationService);
             ExportPath = _exportationService.LoadExportFolderPath();
             ResetState();
+            _settings.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ExperimentSettingsViewModel.ExportFolderPath))
+                    ExportPath = _settings.ExportFolderPath;
+            };
         }
 
         partial void OnExportPathChanged(string value)
@@ -87,9 +96,6 @@ namespace StroopApp.ViewModels.Experiment.Experimenter.End
 
             try
             {
-                _settings.ExportFolderPath = ExportPath;
-                _exportationService.SaveExportFolderPath(ExportPath);
-
                 await _exportationService.ExportDataAsync();
 
                 IsExporting = false;

--- a/StroopApp/ViewModels/Experiment/Experimenter/ExperimentDashBoardPageViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/ExperimentDashBoardPageViewModel.cs
@@ -20,6 +20,9 @@ namespace StroopApp.ViewModels.Experiment.Experimenter
         private readonly INavigationService _experimenterNavigationService;
         private bool _hasNavigatedToEndPage;
 
+        public ExperimentProgressViewModel ExperimentProgressViewModel { get; }
+        public GraphsViewModel GraphsViewModel { get; }
+
         public ExperimentDashBoardPageViewModel(
             ExperimentSettingsViewModel settings,
             INavigationService experimenterNavigationService,
@@ -28,6 +31,9 @@ namespace StroopApp.ViewModels.Experiment.Experimenter
         {
             _settings = settings;
             _experimenterNavigationService = experimenterNavigationService;
+
+            ExperimentProgressViewModel = new ExperimentProgressViewModel(settings);
+            GraphsViewModel = new GraphsViewModel(settings);
 
             _settings.ExperimentContext.PropertyChanged += OnExperimentContextPropertyChanged;
         }
@@ -73,6 +79,8 @@ namespace StroopApp.ViewModels.Experiment.Experimenter
         public void Dispose()
         {
             _settings.ExperimentContext.PropertyChanged -= OnExperimentContextPropertyChanged;
+            ExperimentProgressViewModel.Dispose();
+            GraphsViewModel.Dispose();
         }
     }
 }

--- a/StroopApp/ViewModels/Experiment/Experimenter/GraphsViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Experimenter/GraphsViewModel.cs
@@ -1,0 +1,29 @@
+using StroopApp.ViewModels.State;
+
+namespace StroopApp.ViewModels.Experiment.Experimenter
+{
+    /// <summary>
+    /// Aggregates the three graph sub-ViewModels shown on the experiment dashboard.
+    /// Owns the sub-ViewModels and disposes them when finished.
+    /// </summary>
+    public class GraphsViewModel : IDisposable
+    {
+        public ColumnGraphViewModel ColumnGraphViewModel { get; }
+        public GlobalGraphViewModel GlobalGraphViewModel { get; }
+        public LiveReactionTimeViewModel LiveReactionTimeViewModel { get; }
+
+        public GraphsViewModel(ExperimentSettingsViewModel settings)
+        {
+            ColumnGraphViewModel = new ColumnGraphViewModel(settings);
+            GlobalGraphViewModel = new GlobalGraphViewModel(settings);
+            LiveReactionTimeViewModel = new LiveReactionTimeViewModel(settings);
+        }
+
+        public void Dispose()
+        {
+            (ColumnGraphViewModel as IDisposable)?.Dispose();
+            (GlobalGraphViewModel as IDisposable)?.Dispose();
+            LiveReactionTimeViewModel.Dispose();
+        }
+    }
+}

--- a/StroopApp/ViewModels/Experiment/Participant/Stroop/FixationCrossViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Participant/Stroop/FixationCrossViewModel.cs
@@ -1,0 +1,12 @@
+using StroopApp.Core;
+
+namespace StroopApp.ViewModels.Experiment.Participant.Stroop
+{
+    /// <summary>
+    /// Marker ViewModel for the fixation cross step in a Stroop trial.
+    /// Its presence as the current step ViewModel causes the DataTemplate to render the fixation cross.
+    /// </summary>
+    public class FixationCrossViewModel : ViewModelBase
+    {
+    }
+}

--- a/StroopApp/ViewModels/Experiment/Participant/Stroop/StroopViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Participant/Stroop/StroopViewModel.cs
@@ -3,10 +3,8 @@ using StroopApp.Core;
 using StroopApp.Models;
 using StroopApp.Services.Navigation;
 using StroopApp.ViewModels.State;
-using StroopApp.Views.Experiment.Participant.Stroop;
 using System.Diagnostics;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 namespace StroopApp.ViewModels.Experiment.Participant.Stroop
@@ -27,11 +25,12 @@ namespace StroopApp.ViewModels.Experiment.Participant.Stroop
         }
 
         /// <summary>
-        /// Current UI control displayed to participant.
+        /// Current step ViewModel displayed to the participant.
+        /// Its type determines which DataTemplate is rendered.
         /// Initialized during trial execution.
         /// </summary>
         [ObservableProperty]
-        private UserControl _currentControl = null!;
+        private object? _currentStepViewModel;
 
         /// <summary>
         /// Task completion source for participant input.
@@ -87,7 +86,7 @@ namespace StroopApp.ViewModels.Experiment.Participant.Stroop
                     }
                     Settings.ExperimentContext.CurrentTrial = trial;
 
-                    CurrentControl = new FixationCrossControl();
+                    CurrentStepViewModel = new FixationCrossViewModel();
                     await Task.Delay(Settings.CurrentProfile.FixationDuration, _cancellationTokenSource.Token);
                     if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
                     {
@@ -96,7 +95,7 @@ namespace StroopApp.ViewModels.Experiment.Participant.Stroop
                     }
                     if (Settings.CurrentProfile.HasVisualCue)
                     {
-                        CurrentControl = new VisualCueControl(trial.VisualCue);
+                        CurrentStepViewModel = new VisualCueControlViewModel(trial.VisualCue);
                         await Task.Delay(Settings.CurrentProfile.VisualCueDuration, _cancellationTokenSource.Token);
 
                         if (Settings.ExperimentContext.IsTaskStopped || _cancellationTokenSource.Token.IsCancellationRequested)
@@ -106,8 +105,8 @@ namespace StroopApp.ViewModels.Experiment.Participant.Stroop
                         }
                     }
 
-                    var wordControl = new WordControl(trial.Stimulus.Text, trial.Stimulus.Color);
-                    CurrentControl = wordControl;
+                    var wordViewModel = new WordControlViewModel(trial.Stimulus.Text, trial.Stimulus.Color);
+                    CurrentStepViewModel = wordViewModel;
 
                     await Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                     {
@@ -134,7 +133,7 @@ namespace StroopApp.ViewModels.Experiment.Participant.Stroop
                         trial.ReactionTime = _inputTcs.Task.Result;
                         Settings.ExperimentContext.CurrentBlock.TrialTimes.Add(trial.ReactionTime);
                         Settings.ExperimentContext.ReactionPoints.Add(new ReactionTimePoint(trial.TrialNumber, trial.ReactionTime, trial.IsValidResponse));
-                        CurrentControl = new FixationCrossControl();
+                        CurrentStepViewModel = new FixationCrossViewModel();
                     }
                     else if (!delayTask.IsCanceled)
                     {

--- a/StroopApp/ViewModels/Experiment/Participant/Stroop/VisualCueControlViewModel.cs
+++ b/StroopApp/ViewModels/Experiment/Participant/Stroop/VisualCueControlViewModel.cs
@@ -1,14 +1,17 @@
 ﻿using StroopApp.Models;
 
-/// <summary>
-/// ViewModel for displaying visual cues during Stroop test trials.
-/// </summary>
-public class VisualCueControlViewModel
+namespace StroopApp.ViewModels.Experiment.Participant.Stroop
 {
-    public VisualCueType VisualCue { get; set; }
-
-    public VisualCueControlViewModel(VisualCueType visualCue)
+    /// <summary>
+    /// ViewModel for displaying visual cues during Stroop test trials.
+    /// </summary>
+    public class VisualCueControlViewModel
     {
-        VisualCue = visualCue;
+        public VisualCueType VisualCue { get; set; }
+
+        public VisualCueControlViewModel(VisualCueType visualCue)
+        {
+            VisualCue = visualCue;
+        }
     }
 }

--- a/StroopApp/Views/Configuration/ConfigurationPage.xaml
+++ b/StroopApp/Views/Configuration/ConfigurationPage.xaml
@@ -1,10 +1,7 @@
 ﻿<Page x:Class="StroopApp.Views.ConfigurationPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:ui="http://schemas.modernwpf.com/2019"
-      xmlns:viewsProfile="clr-namespace:StroopApp.Views.Profile"
-      xmlns:viewsKeyMapping="clr-namespace:StroopApp.Views.KeyMapping"
-      xmlns:viewsParticipant="clr-namespace:StroopApp.Views.Participant">
+      xmlns:ui="http://schemas.modernwpf.com/2019">
     <Grid x:Name="MainGrid"
           Margin="12">
         <Grid.RowDefinitions>
@@ -22,14 +19,21 @@
                    Style="{DynamicResource HeaderTextBlockStyle}"
                    HorizontalAlignment="Left"
                    Margin="0,0,0,12" />
-        <Grid x:Name="KeyMappingContainer"
-              Grid.Row="3">
+        <ContentControl Grid.Row="1"
+                        Content="{Binding ProfileViewModel}" />
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="0.7*" />
                 <ColumnDefinition Width="12" />
                 <ColumnDefinition Width="0.3*" />
             </Grid.ColumnDefinitions>
+            <ContentControl Grid.Column="0"
+                            Content="{Binding KeyMappingViewModel}" />
+            <ContentControl Grid.Column="2"
+                            Content="{Binding ExportFolderSelectorViewModel}" />
         </Grid>
+        <ContentControl Grid.Row="5"
+                        Content="{Binding ParticipantViewModel}" />
         <StackPanel Grid.Row="7"
                     HorizontalAlignment="Center">
             <Button Content="{Binding Source={StaticResource Loc}, Path=[Button_LaunchExperiment]}"

--- a/StroopApp/Views/Configuration/ConfigurationPage.xaml.cs
+++ b/StroopApp/Views/Configuration/ConfigurationPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿using StroopApp.Models;
-using StroopApp.Services.Exportation;
+﻿using StroopApp.Services.Exportation;
 using StroopApp.Services.KeyMapping;
 using StroopApp.Services.Language;
 using StroopApp.Services.Navigation;
@@ -11,10 +10,6 @@ using StroopApp.ViewModels.Configuration;
 using StroopApp.ViewModels.Configuration.Participant;
 using StroopApp.ViewModels.Configuration.Profile;
 using StroopApp.ViewModels.State;
-using StroopApp.Views.Configuration;
-using StroopApp.Views.KeyMapping;
-using StroopApp.Views.Participant;
-using StroopApp.Views.Profile;
 using System.Windows.Controls;
 
 namespace StroopApp.Views
@@ -63,21 +58,16 @@ namespace StroopApp.Views
             var keyMappingViewModel = new KeyMappingViewModel(_keyMappingService);
             var exportFolderSelectorViewModel = new ExportFolderSelectorViewModel(_settings, _exportationService);
 
-            DataContext = new ConfigurationPageViewModel(_settings, profileViewModel, participantViewModel, keyMappingViewModel, navigationService, _windowManager, _trialGenerationService, _languageService);
-
-            var profileManagementView = new ProfileManagementView(profileViewModel);
-            var participantManagementView = new ParticipantManagementView(participantViewModel);
-            var keyMappingView = new KeyMappingView(keyMappingViewModel);
-            var exportFolderView = new ExportFolderSelectorView(exportFolderSelectorViewModel);
-
-            MainGrid.Children.Add(profileManagementView);
-            Grid.SetRow(profileManagementView, 1);
-            KeyMappingContainer.Children.Add(keyMappingView);
-            Grid.SetColumn(keyMappingView, 0);
-            KeyMappingContainer.Children.Add(exportFolderView);
-            Grid.SetColumn(exportFolderView, 2);
-            MainGrid.Children.Add(participantManagementView);
-            Grid.SetRow(participantManagementView, 5);
+            DataContext = new ConfigurationPageViewModel(
+                _settings,
+                profileViewModel,
+                participantViewModel,
+                keyMappingViewModel,
+                exportFolderSelectorViewModel,
+                navigationService,
+                _windowManager,
+                _trialGenerationService,
+                _languageService);
         }
     }
 }

--- a/StroopApp/Views/Configuration/ExportFolderSelectorView.xaml.cs
+++ b/StroopApp/Views/Configuration/ExportFolderSelectorView.xaml.cs
@@ -1,14 +1,12 @@
-﻿using StroopApp.ViewModels.Configuration;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Configuration
 {
     public partial class ExportFolderSelectorView : UserControl
     {
-        public ExportFolderSelectorView(ExportFolderSelectorViewModel viewModel)
+        public ExportFolderSelectorView()
         {
             InitializeComponent();
-            DataContext = viewModel;
         }
     }
 }

--- a/StroopApp/Views/Configuration/KeyMapping/KeyMappingView.xaml.cs
+++ b/StroopApp/Views/Configuration/KeyMapping/KeyMappingView.xaml.cs
@@ -1,14 +1,12 @@
-﻿using StroopApp.ViewModels.Configuration;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.KeyMapping
 {
     public partial class KeyMappingView : UserControl
     {
-        public KeyMappingView(KeyMappingViewModel viewModel)
+        public KeyMappingView()
         {
             InitializeComponent();
-            DataContext = viewModel;
         }
     }
 }

--- a/StroopApp/Views/Configuration/Participant/ParticipantManagementView.xaml.cs
+++ b/StroopApp/Views/Configuration/Participant/ParticipantManagementView.xaml.cs
@@ -1,14 +1,12 @@
-﻿using StroopApp.ViewModels.Configuration.Participant;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Participant
 {
     public partial class ParticipantManagementView : UserControl
     {
-        public ParticipantManagementView(ParticipantManagementViewModel viewModel)
+        public ParticipantManagementView()
         {
             InitializeComponent();
-            DataContext = viewModel;
         }
     }
 }

--- a/StroopApp/Views/Configuration/Profile/ProfileManagementView.xaml.cs
+++ b/StroopApp/Views/Configuration/Profile/ProfileManagementView.xaml.cs
@@ -1,15 +1,12 @@
 ﻿using System.Windows.Controls;
-using StroopApp.Services.Profile;
-using StroopApp.ViewModels.Configuration.Profile;
 
 namespace StroopApp.Views.Profile
 {
     public partial class ProfileManagementView : UserControl
     {
-        public ProfileManagementView(ProfileManagementViewModel viewModel)
+        public ProfileManagementView()
         {
             InitializeComponent();
-            DataContext = viewModel;
         }
     }
 }

--- a/StroopApp/Views/Experiment/Experimenter/End/EndExperimentPage.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/End/EndExperimentPage.xaml
@@ -184,13 +184,18 @@
                 </Border>
             </Grid>
         </Border>
-        <Border Grid.Row="4"
-                Grid.ColumnSpan="3"
-                Background="{DynamicResource SystemControlBackgroundAltMediumBrush}"
+        <Border Background="{DynamicResource SystemControlBackgroundAltMediumBrush}"
                 CornerRadius="8"
                 Padding="16"
                 BorderThickness="0.5"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"></Border>
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                Grid.Row="2"
+                Grid.Column="2">
+            <ContentControl Content="{Binding LiveReactionTimeViewModel}" />
+        </Border>
+        <ContentControl Grid.Row="4"
+                        Grid.ColumnSpan="3"
+                        Content="{Binding GlobalGraphViewModel}" />
         <ui:SimpleStackPanel Orientation="Horizontal"
                              Spacing="16"
                              Grid.Row="6"

--- a/StroopApp/Views/Experiment/Experimenter/End/EndExperimentPage.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/End/EndExperimentPage.xaml.cs
@@ -3,7 +3,6 @@ using StroopApp.Services.Navigation;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.Experiment.Experimenter.End;
 using StroopApp.ViewModels.State;
-using StroopApp.Views.Experiment.Experimenter.Graphs;
 using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Experimenter
@@ -25,19 +24,12 @@ namespace StroopApp.Views.Experiment.Experimenter
             _settings = settings;
             _exportationService = exportationService;
             _windowManager = windowManager;
+            Unloaded += (s, e) => (DataContext as IDisposable)?.Dispose();
         }
 
         private void Initialize(INavigationService navigationService)
         {
             DataContext = new EndExperimentPageViewModel(_settings, _exportationService, navigationService, _windowManager);
-            var globalGraph = new GlobalGraphView(_settings);
-            MainGrid.Children.Add(globalGraph);
-            Grid.SetRow(globalGraph, 4);
-            Grid.SetColumnSpan(globalGraph, 3);
-            var liveReactionTimeView = new LiveReactionTimeView(_settings);
-            MainGrid.Children.Add(liveReactionTimeView);
-            Grid.SetRow(liveReactionTimeView, 2);
-            Grid.SetColumn(liveReactionTimeView, 2);
         }
     }
 }

--- a/StroopApp/Views/Experiment/Experimenter/End/ExportEndExperimentWindow.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/End/ExportEndExperimentWindow.xaml
@@ -11,13 +11,14 @@
         WindowStartupLocation="CenterScreen"
         ui:WindowHelper.UseModernWindowStyle="True"
         Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
-    <Grid x:Name="EndGrid"
-          Margin="16">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="12" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <ContentControl Grid.Row="0"
+                        Content="{Binding ExportFolderSelectorViewModel}" />
         <ContentControl Grid.Row="2"
                         Content="{Binding}">
             <ContentControl.Style>

--- a/StroopApp/Views/Experiment/Experimenter/End/ExportEndExperimentWindow.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/End/ExportEndExperimentWindow.xaml.cs
@@ -1,12 +1,8 @@
-﻿using StroopApp.Models;
-using StroopApp.Services.Exportation;
+﻿using StroopApp.Services.Exportation;
 using StroopApp.Services.Navigation;
-using StroopApp.ViewModels.Configuration;
 using StroopApp.ViewModels.Experiment.Experimenter.End;
 using StroopApp.ViewModels.State;
-using StroopApp.Views.Configuration;
 using System.Windows;
-using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Experimenter.End
 {
@@ -16,12 +12,6 @@ namespace StroopApp.Views.Experiment.Experimenter.End
 		{
 			InitializeComponent();
 			DataContext = new ExportEndExperimentWindowViewModel(Settings, exportationService, closeWindow: () => Close(), setDialogResult: result => DialogResult = result, experimenterNavigationService);
-			var folderSelectorVM = new ExportFolderSelectorViewModel(Settings, exportationService);
-			var folderSelectorView = new ExportFolderSelectorView(folderSelectorVM);
-
-			EndGrid.Children.Add(folderSelectorView);
-			Grid.SetRow(folderSelectorView, 0);
 		}
-
 	}
 }

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml
@@ -3,18 +3,13 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ui="http://schemas.modernwpf.com/2019"
       Title="ExperimentDashBoardPage">
-    <Grid x:Name="MainGrid"
-          Margin="12">
+    <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="12" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -24,12 +19,15 @@
                        Style="{DynamicResource HeaderTextBlockStyle}"
                        HorizontalAlignment="Left"
                        Margin="0,0,0,12" />
-            <Button 
-                Grid.Column="1"
-                Content="{Binding Source={StaticResource Loc}, Path=[Button_StopTask]}"
+            <Button Grid.Column="1"
+                    Content="{Binding Source={StaticResource Loc}, Path=[Button_StopTask]}"
                     Style="{DynamicResource AccentButtonStyle}"
                     Command="{Binding StopTaskCommand}"
                     ToolTip="{Binding Source={StaticResource Loc}, Path=[Tooltip_StopTask]}" />
         </Grid>
+        <ContentControl Grid.Row="1"
+                        Content="{Binding ExperimentProgressViewModel}" />
+        <ContentControl Grid.Row="3"
+                        Content="{Binding GraphsViewModel}" />
     </Grid>
 </Page>

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentDashBoardPage.xaml.cs
@@ -1,11 +1,8 @@
-﻿using StroopApp.Models;
-using StroopApp.Services.Language;
+﻿using StroopApp.Services.Language;
 using StroopApp.Services.Navigation;
 using StroopApp.Services.Window;
 using StroopApp.ViewModels.Experiment.Experimenter;
 using StroopApp.ViewModels.State;
-using StroopApp.Views.Experiment.Experimenter;
-using StroopApp.Views.Experiment.Experimenter.Graphs;
 using System.Windows.Controls;
 
 namespace StroopApp.Views
@@ -32,13 +29,7 @@ namespace StroopApp.Views
 
         private void Initialize(INavigationService navigationService)
         {
-            var experimentProfileView = new ExperimentProgressView(_settings);
-            var graphsView = new GraphsView(_settings);
             DataContext = new ExperimentDashBoardPageViewModel(_settings, navigationService, _windowManager, _languageService);
-            MainGrid.Children.Add(experimentProfileView);
-            Grid.SetRow(experimentProfileView, 1);
-            MainGrid.Children.Add(graphsView);
-            Grid.SetRow(graphsView, 3);
         }
     }
 }

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentProgressView.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentProgressView.xaml
@@ -17,9 +17,9 @@
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="0.2*" />
-            <ColumnDefinition Width="0.3*" />
-            <ColumnDefinition Width="0.5*" />
+            <ColumnDefinition Width="0.25*" />
+            <ColumnDefinition Width="0.25*" />
+            <ColumnDefinition Width="0.7*" />
         </Grid.ColumnDefinitions>
         <Border Grid.Column="0"
                 Background="{DynamicResource SystemControlBackgroundAltMediumBrush}"

--- a/StroopApp/Views/Experiment/Experimenter/ExperimentProgressView.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/ExperimentProgressView.xaml.cs
@@ -1,15 +1,12 @@
-﻿using StroopApp.ViewModels.Experiment.Experimenter;
-using StroopApp.ViewModels.State;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
+
 namespace StroopApp.Views.Experiment.Experimenter
 {
     public partial class ExperimentProgressView : UserControl
     {
-        public ExperimentProgressView(ExperimentSettingsViewModel Settings)
+        public ExperimentProgressView()
         {
             InitializeComponent();
-            DataContext = new ExperimentProgressViewModel(Settings);
-            Unloaded += (s, e) => (DataContext as IDisposable)?.Dispose();
         }
     }
 }

--- a/StroopApp/Views/Experiment/Experimenter/Graphs/ColumnGraphView.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/Graphs/ColumnGraphView.xaml.cs
@@ -1,16 +1,12 @@
-﻿using StroopApp.Models;
-using StroopApp.ViewModels.Experiment.Experimenter;
-using StroopApp.ViewModels.State;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Experimenter.Graphs
 {
     public partial class ColumnGraphView : UserControl
     {
-        public ColumnGraphView(ExperimentSettingsViewModel settings)
+        public ColumnGraphView()
         {
             InitializeComponent();
-            DataContext = new ColumnGraphViewModel(settings);
         }
     }
 }

--- a/StroopApp/Views/Experiment/Experimenter/Graphs/GlobalGraphView.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/Graphs/GlobalGraphView.xaml.cs
@@ -1,17 +1,12 @@
-﻿using StroopApp.Models;
-using StroopApp.ViewModels.Experiment.Experimenter;
-using StroopApp.ViewModels.State;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Experimenter.Graphs
 {
     public partial class GlobalGraphView : UserControl
     {
-        public GlobalGraphView(ExperimentSettingsViewModel settings)
+        public GlobalGraphView()
         {
             InitializeComponent();
-            DataContext = new GlobalGraphViewModel(settings);
         }
     }
 }
-

--- a/StroopApp/Views/Experiment/Experimenter/Graphs/GraphsView.xaml
+++ b/StroopApp/Views/Experiment/Experimenter/Graphs/GraphsView.xaml
@@ -13,8 +13,7 @@
             Padding="16"
             BorderThickness="0.5"
             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
-        <Grid x:Name="MainGrid"
-              Margin="0">
+        <Grid Margin="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="0.8*" />
                 <ColumnDefinition Width="8" />
@@ -30,6 +29,16 @@
             <TextBlock Text="{Binding Source={StaticResource Loc}, Path=[Title_GraphsView]}"
                        Style="{DynamicResource TitleTextBlockStyle}"
                        Grid.Row="0" />
+            <ContentControl Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="3"
+                            Content="{Binding GlobalGraphViewModel}" />
+            <ContentControl Grid.Row="4"
+                            Grid.Column="0"
+                            Content="{Binding ColumnGraphViewModel}" />
+            <ContentControl Grid.Row="4"
+                            Grid.Column="2"
+                            Content="{Binding LiveReactionTimeViewModel}" />
         </Grid>
     </Border>
 </UserControl>

--- a/StroopApp/Views/Experiment/Experimenter/Graphs/GraphsView.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/Graphs/GraphsView.xaml.cs
@@ -1,27 +1,12 @@
-﻿using StroopApp.Models;
-using StroopApp.ViewModels.State;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Experimenter.Graphs
 {
 	public partial class GraphsView : UserControl
 	{
-		public GraphsView(ExperimentSettingsViewModel settings)
+		public GraphsView()
 		{
 			InitializeComponent();
-			var columnGraphView = new ColumnGraphView(settings);
-			var globalGraphView = new GlobalGraphView(settings);
-			var liveReactionTimeView = new LiveReactionTimeView(settings);
-			MainGrid.Children.Add(globalGraphView);
-			Grid.SetRow(globalGraphView, 2);
-			Grid.SetColumnSpan(globalGraphView, 3);
-			Grid.SetColumn(globalGraphView, 0);
-			MainGrid.Children.Add(columnGraphView);
-			Grid.SetRow(columnGraphView, 4);
-			Grid.SetColumn(columnGraphView, 0);
-			MainGrid.Children.Add(liveReactionTimeView);
-			Grid.SetRow(liveReactionTimeView, 4);
-			Grid.SetColumn(liveReactionTimeView, 2);
 		}
 	}
 }

--- a/StroopApp/Views/Experiment/Experimenter/Graphs/LiveReactionTimeView.xaml.cs
+++ b/StroopApp/Views/Experiment/Experimenter/Graphs/LiveReactionTimeView.xaml.cs
@@ -1,19 +1,12 @@
-﻿using StroopApp.Models;
-using StroopApp.ViewModels.Experiment.Experimenter;
-using StroopApp.ViewModels.State;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Experimenter.Graphs
 {
 	public partial class LiveReactionTimeView : UserControl
 	{
-		private readonly ExperimentSettingsViewModel _settings;
-
-		public LiveReactionTimeView(ExperimentSettingsViewModel settings)
+		public LiveReactionTimeView()
 		{
 			InitializeComponent();
-			_settings = settings;
-			DataContext = new LiveReactionTimeViewModel(settings);
             Unloaded += (s, e) => (DataContext as IDisposable)?.Dispose();
         }
 	}

--- a/StroopApp/Views/Experiment/Participant/Stroop/StroopPage.xaml
+++ b/StroopApp/Views/Experiment/Participant/Stroop/StroopPage.xaml
@@ -6,6 +6,6 @@
       KeyDown="StroopPage_KeyDown"
       Title="Stroop">
     <Grid>
-        <ContentControl Content="{Binding CurrentControl}" />
+        <ContentControl Content="{Binding CurrentStepViewModel}" />
     </Grid>
 </Page>

--- a/StroopApp/Views/Experiment/Participant/Stroop/VisualCueControl.xaml.cs
+++ b/StroopApp/Views/Experiment/Participant/Stroop/VisualCueControl.xaml.cs
@@ -1,13 +1,12 @@
-﻿using StroopApp.Models;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
+
 namespace StroopApp.Views.Experiment.Participant.Stroop
 {
     public partial class VisualCueControl : UserControl
     {
-        public VisualCueControl(VisualCueType visualCue)
+        public VisualCueControl()
         {
             InitializeComponent();
-            DataContext = new VisualCueControlViewModel(visualCue);
         }
     }
 }

--- a/StroopApp/Views/Experiment/Participant/Stroop/WordControl.xaml.cs
+++ b/StroopApp/Views/Experiment/Participant/Stroop/WordControl.xaml.cs
@@ -1,14 +1,12 @@
-﻿using StroopApp.ViewModels.Experiment.Participant.Stroop;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace StroopApp.Views.Experiment.Participant.Stroop
 {
     public partial class WordControl : UserControl
     {
-        public WordControl(string label, string color)
+        public WordControl()
         {
             InitializeComponent();
-            DataContext = new WordControlViewModel(label, color);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR is the dedicated follow-up branch mentioned previously, focusing entirely on the DataTemplate migration. It aims to modularize the ViewModels, improve UI rendering flexibility, and enhance resource management across the experiment dashboards and configuration pages.

For easier reviewing, all intermediate working commits have been squashed into a single cohesive commit.

## Context & Motivation
**Note:** As outlined in the notes of the previous PR, the architectural modernization driven by recent mentorship continues here. To facilitate this specific phase, AI-assisted tools were utilized to handle and remove the boilerplate migration code, ensuring a clean and consistent implementation of the new UI rendering and MVVM patterns.

## Changes

### DataTemplates & UI rendering
* A new `Resources/DataTemplates.xaml` file is introduced and merged into `App.xaml` for application-wide use.
* Automatic mapping between ViewModels and Views is now fully functional, replacing direct `UserControl` instantiation.
* A `FixationCrossViewModel` marker is added to support this new template-based rendering during Stroop trials.

### ViewModel architecture & Lifecycle
* A new `GraphsViewModel` is created to aggregate and manage all graph-related ViewModels on the dashboard.
* Parent ViewModels (`ExperimentDashBoardPageViewModel`, `EndExperimentPageViewModel`, `ConfigurationPageViewModel`) now cleanly expose their sub-ViewModels as public properties.
* Resource management is enhanced: parent ViewModels now implement `IDisposable` and ensure their child components are properly disposed of when no longer needed.

### Export & Configuration
* A dedicated `ExportFolderSelectorViewModel` is extracted to handle export path selection and improve testability.
* The export path is now kept in sync with settings changes automatically.
* Unit tests are updated with dummy folder selectors to account for the new dependencies.

### Error handling & Clean up
* Proper error dialogs are now displayed during the experiment workflow instead of silently failing in the debug output.
* Unused imports are cleaned up across the codebase.